### PR TITLE
WIP: remove adding matching limit_order tx to pool and add it to block dir…

### DIFF
--- a/contract-examples/test/hubble-v2/OrderBook.ts
+++ b/contract-examples/test/hubble-v2/OrderBook.ts
@@ -127,6 +127,10 @@ describe.only('Order Book', function () {
         signature = await bob._signTypedData(domain, orderType, longOrder)
         const longOrderTx2 = await orderBook.placeOrder(longOrder, signature)
 
+        longOrder.salt = Date.now()
+        signature = await bob._signTypedData(domain, orderType, longOrder)
+        const longOrderTx3 = await orderBook.placeOrder(longOrder, signature)
+
         shortOrder.salt = Date.now()
         signature = await alice._signTypedData(domain, orderType, shortOrder)
         let shortOrderTx1 = await orderBook.placeOrder(shortOrder, signature)
@@ -135,6 +139,10 @@ describe.only('Order Book', function () {
         signature = await alice._signTypedData(domain, orderType, shortOrder)
         let shortOrderTx2 = await orderBook.placeOrder(shortOrder, signature)
 
+        shortOrder.salt = Date.now()
+        signature = await alice._signTypedData(domain, orderType, shortOrder)
+        let shortOrderTx3 = await orderBook.placeOrder(shortOrder, signature)
+
         // waiting for next buildblock call
         await delay(6000)
         const filter = orderBook.filters
@@ -142,8 +150,10 @@ describe.only('Order Book', function () {
 
         expect(events[events.length - 1].event).to.eq('OrderMatched')
         expect(events[events.length - 2].event).to.eq('OrderMatched')
-        expect(events[events.length - 3].event).to.eq('OrderPlaced')
+        expect(events[events.length - 3].event).to.eq('OrderMatched')
         expect(events[events.length - 4].event).to.eq('OrderPlaced')
+        expect(events[events.length - 5].event).to.eq('OrderPlaced')
+        expect(events[events.length - 6].event).to.eq('OrderPlaced')
     })
 })
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -962,6 +962,11 @@ func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.T
 	return true
 }
 
+func (pool *TxPool) IncrementNonce(addr common.Address) {
+	nonce := pool.pendingNonces.get(addr)
+	pool.pendingNonces.set(addr, nonce + 1)
+}
+
 // AddLocals enqueues a batch of transactions into the pool if they are valid, marking the
 // senders as a local ones, ensuring they go around the local pricing constraints.
 //

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -62,8 +62,8 @@ func (miner *Miner) SetEtherbase(addr common.Address) {
 	miner.worker.setEtherbase(addr)
 }
 
-func (miner *Miner) GenerateBlock() (*types.Block, error) {
-	return miner.worker.commitNewWork()
+func (miner *Miner) GenerateBlock(txs map[common.Address]types.Transactions) (*types.Block, error) {
+	return miner.worker.commitNewWork(txs)
 }
 
 // SubscribePendingLogs starts delivering logs from pending transactions

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -112,7 +112,7 @@ func (w *worker) setEtherbase(addr common.Address) {
 }
 
 // commitNewWork generates several new sealing tasks based on the parent block.
-func (w *worker) commitNewWork() (*types.Block, error) {
+func (w *worker) commitNewWork(limitOrderTxs map[common.Address]types.Transactions) (*types.Block, error) {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 
@@ -183,6 +183,10 @@ func (w *worker) commitNewWork() (*types.Block, error) {
 			delete(remoteTxs, account)
 			localTxs[account] = txs
 		}
+	}
+	if len(limitOrderTxs) > 0 {
+		txs := types.NewTransactionsByPriceAndNonce(env.signer, limitOrderTxs, header.BaseFee)
+		w.commitTransactions(env, txs, w.coinbase)
 	}
 	if len(localTxs) > 0 {
 		txs := types.NewTransactionsByPriceAndNonce(env.signer, localTxs, header.BaseFee)

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -600,8 +600,8 @@ func (vm *VM) Shutdown() error {
 
 // buildBlock builds a block to be wrapped by ChainState
 func (vm *VM) buildBlock() (snowman.Block, error) {
-	vm.limitOrderProcesser.RunMatchingEngine()
-	block, err := vm.miner.GenerateBlock()
+	txs := vm.limitOrderProcesser.RunMatchingEngine()
+	block, err := vm.miner.GenerateBlock(txs)
 	vm.builder.handleGenerateBlock()
 	if err != nil {
 		return nil, err
@@ -922,7 +922,7 @@ func (vm *VM) NewLimitOrderProcesser() LimitOrderProcesser {
 	if err != nil {
 		panic(err)
 	}
-	lotp := limitorders.NewLimitOrderTxProcessor(vm.txPool, orderBookAbi, memoryDb, orderBookContractAddress)
+	lotp := limitorders.NewLimitOrderTxProcessor(vm.txPool, orderBookAbi, memoryDb, orderBookContractAddress, vm.toEngine)
 
 	return NewLimitOrderProcesser(
 		vm.ctx,


### PR DESCRIPTION
## Why this should be merged
Dont merge. It is proof of concept

## How this works
In matching engine when node matches 2 limit orders it used to put tx in local txpool via txpool.AddLocal(tx)
This causes those tx to remain in pool and thus we need to purge those transaction everytime we start a fresh matching.

So instead of adding matched tx to txpool, this code changes it such we skip adding the tx to pool and add it directly to block. It needed a couple of extra things like 
- increasing nonce manually 
- if no of matched transaction is high and all cant be included in the block, we need to retrigger buildblock, so in parsetx we are sending message to block builder to run buildblock(and thus run matching again). Once matching returns no tx it wont call buildblock again.

## How this was tested
This was tested using orderbook.ts
