### PR TITLE
change price check in matching engine to match if longOrder price >= …

### DIFF
--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -81,19 +81,29 @@ func (lop *limitOrderProcesser) RunMatchingEngine() {
 			if getUnFilledBaseAssetQuantity(shortOrders[j]) == 0 {
 				continue
 			}
-			if longOrders[i].Price >= shortOrders[j].Price {
-				fillAmount := math.Abs(math.Min(float64(getUnFilledBaseAssetQuantity(longOrders[i])), float64(-(getUnFilledBaseAssetQuantity(shortOrders[j])))))
-				err := lop.limitOrderTxProcessor.ExecuteMatchedOrdersTx(longOrders[i], shortOrders[j], uint(fillAmount))
-				if err == nil {
-					longOrders[i].FilledBaseAssetQuantity = longOrders[i].FilledBaseAssetQuantity + int(fillAmount)
-					shortOrders[j].FilledBaseAssetQuantity = shortOrders[j].FilledBaseAssetQuantity - int(fillAmount)
-				}
-			} else {
+			var ordersMatched bool
+			longOrders[i], shortOrders[j], ordersMatched = matchLongAndShortOrder(lop.limitOrderTxProcessor, longOrders[i], shortOrders[j])
+			if !ordersMatched {
 				i = len(longOrders)
 				break
 			}
 		}
 	}
+}
+
+func matchLongAndShortOrder(lotp limitorders.LimitOrderTxProcessor, longOrder limitorders.LimitOrder, shortOrder limitorders.LimitOrder) (limitorders.LimitOrder, limitorders.LimitOrder, bool) {
+	if longOrder.Price >= shortOrder.Price {
+		fillAmount := math.Abs(math.Min(float64(getUnFilledBaseAssetQuantity(longOrder)), float64(-(getUnFilledBaseAssetQuantity(shortOrder)))))
+		if fillAmount != 0 {
+			err := lotp.ExecuteMatchedOrdersTx(longOrder, shortOrder, uint(fillAmount))
+			if err == nil {
+				longOrder.FilledBaseAssetQuantity += int(fillAmount)
+				shortOrder.FilledBaseAssetQuantity -= int(fillAmount)
+				return longOrder, shortOrder, true
+			}
+		}
+	}
+	return longOrder, shortOrder, false
 }
 
 func (lop *limitOrderProcesser) listenAndStoreLimitOrderTransactions() {

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -81,13 +81,16 @@ func (lop *limitOrderProcesser) RunMatchingEngine() {
 			if getUnFilledBaseAssetQuantity(shortOrders[j]) == 0 {
 				continue
 			}
-			if longOrders[i].Price == shortOrders[j].Price {
+			if longOrders[i].Price >= shortOrders[j].Price {
 				fillAmount := math.Abs(math.Min(float64(getUnFilledBaseAssetQuantity(longOrders[i])), float64(-(getUnFilledBaseAssetQuantity(shortOrders[j])))))
 				err := lop.limitOrderTxProcessor.ExecuteMatchedOrdersTx(longOrders[i], shortOrders[j], uint(fillAmount))
 				if err == nil {
 					longOrders[i].FilledBaseAssetQuantity = longOrders[i].FilledBaseAssetQuantity + int(fillAmount)
 					shortOrders[j].FilledBaseAssetQuantity = shortOrders[j].FilledBaseAssetQuantity - int(fillAmount)
 				}
+			} else {
+				i = len(longOrders)
+				break
 			}
 		}
 	}

--- a/plugin/evm/limit_order_test.go
+++ b/plugin/evm/limit_order_test.go
@@ -286,3 +286,32 @@ func createLimitOrder(positionType string, userAddress string, baseAssetQuantity
 		BlockNumber:             blockNumber,
 	}
 }
+
+func TestGetUnfilledBaseAssetQuantity(t *testing.T) {
+	t.Run("When limit FilledBaseAssetQuantity is zero, it returns BaseAssetQuantity", func(t *testing.T) {
+		longOrder := getLongOrder()
+		longOrderFilledBaseQuantity := 0
+		longOrder.FilledBaseAssetQuantity = longOrderFilledBaseQuantity
+		expectedUnFilledForLongOrder := longOrder.BaseAssetQuantity - longOrderFilledBaseQuantity
+		assert.Equal(t, expectedUnFilledForLongOrder, getUnFilledBaseAssetQuantity(longOrder))
+
+		shortOrder := getShortOrder()
+		shortOrderFilledBaseQuantity := 0
+		shortOrder.FilledBaseAssetQuantity = shortOrderFilledBaseQuantity
+		expectedUnFilledForShortOrder := shortOrder.BaseAssetQuantity - shortOrderFilledBaseQuantity
+		assert.Equal(t, expectedUnFilledForShortOrder, getUnFilledBaseAssetQuantity(shortOrder))
+	})
+	t.Run("When limit FilledBaseAssetQuantity is not zero, it returns BaseAssetQuantity - FilledBaseAssetQuantity", func(t *testing.T) {
+		longOrder := getLongOrder()
+		longOrderFilledBaseQuantity := 5
+		longOrder.FilledBaseAssetQuantity = longOrderFilledBaseQuantity
+		expectedUnFilledForLongOrder := longOrder.BaseAssetQuantity - longOrderFilledBaseQuantity
+		assert.Equal(t, expectedUnFilledForLongOrder, getUnFilledBaseAssetQuantity(longOrder))
+
+		shortOrder := getShortOrder()
+		shortOrderFilledBaseQuantity := -5
+		shortOrder.FilledBaseAssetQuantity = shortOrderFilledBaseQuantity
+		expectedUnFilledForShortOrder := shortOrder.BaseAssetQuantity - shortOrderFilledBaseQuantity
+		assert.Equal(t, expectedUnFilledForShortOrder, getUnFilledBaseAssetQuantity(shortOrder))
+	})
+}

--- a/plugin/evm/limit_order_test.go
+++ b/plugin/evm/limit_order_test.go
@@ -52,8 +52,8 @@ func setupDependencies(t *testing.T) (*MockLimitOrderDatabase, *MockLimitOrderTx
 }
 
 func TestRunMatchingEngine(t *testing.T) {
-	t.Run("Matching engine does not make call ExecuteMatchedOrders when no long orders are present in memorydb", func(t *testing.T) {
-		t.Run("Matching engine does not make call ExecuteMatchedOrders when no short orders are present", func(t *testing.T) {
+	t.Run("when no long orders are present in memorydb", func(t *testing.T) {
+		t.Run("when no short orders are present, matching engine does not call ExecuteMatchedOrders", func(t *testing.T) {
 			db, lotp, lop := setupDependencies(t)
 			longOrders := make([]limitorders.LimitOrder, 0)
 			shortOrders := make([]limitorders.LimitOrder, 0)
@@ -63,7 +63,7 @@ func TestRunMatchingEngine(t *testing.T) {
 			lop.RunMatchingEngine()
 			lotp.AssertNotCalled(t, "ExecuteMatchedOrdersTx", mock.Anything, mock.Anything, mock.Anything)
 		})
-		t.Run("Matching engine does not make call ExecuteMatchedOrders when short orders are present", func(t *testing.T) {
+		t.Run("when short orders are present, matching engine does not call ExecuteMatchedOrders", func(t *testing.T) {
 			db, lotp, lop := setupDependencies(t)
 			longOrders := make([]limitorders.LimitOrder, 0)
 			shortOrders := make([]limitorders.LimitOrder, 0)
@@ -75,8 +75,8 @@ func TestRunMatchingEngine(t *testing.T) {
 			lotp.AssertNotCalled(t, "ExecuteMatchedOrdersTx", mock.Anything, mock.Anything, mock.Anything)
 		})
 	})
-	t.Run("Matching engine does not make call ExecuteMatchedOrders when no short orders are present in memorydb", func(t *testing.T) {
-		t.Run("Matching engine does not make call ExecuteMatchedOrders when long orders are present", func(t *testing.T) {
+	t.Run("when long orders are present in memorydb", func(t *testing.T) {
+		t.Run("when no short orders are present in memorydb, matching engine does not call ExecuteMatchedOrders", func(t *testing.T) {
 			db, lotp, lop := setupDependencies(t)
 			longOrders := make([]limitorders.LimitOrder, 0)
 			shortOrders := make([]limitorders.LimitOrder, 0)
@@ -88,158 +88,149 @@ func TestRunMatchingEngine(t *testing.T) {
 			lop.RunMatchingEngine()
 			lotp.AssertNotCalled(t, "ExecuteMatchedOrdersTx", mock.Anything, mock.Anything, mock.Anything)
 		})
-	})
-	t.Run("When long and short orders are present in db", func(t *testing.T) {
-		t.Run("Matching engine does not make call ExecuteMatchedOrders when price is not same", func(t *testing.T) {
-			db, lotp, lop := setupDependencies(t)
-			longOrders := make([]limitorders.LimitOrder, 0)
-			shortOrders := make([]limitorders.LimitOrder, 0)
-			longOrder := getLongOrder()
-			longOrders = append(longOrders, longOrder)
-			shortOrder := getShortOrder()
-			shortOrder.Price = shortOrder.Price - 2
-			shortOrders = append(shortOrders, shortOrder)
-			db.On("GetLongOrders").Return(longOrders)
-			db.On("GetShortOrders").Return(shortOrders)
-			lotp.On("PurgeLocalTx").Return(nil)
-			lop.RunMatchingEngine()
-			lotp.AssertNotCalled(t, "ExecuteMatchedOrdersTx", mock.Anything, mock.Anything, mock.Anything)
-		})
-		t.Run("When price is same", func(t *testing.T) {
-			t.Run("When long order and short order's unfulfilled quantity is same", func(t *testing.T) {
-				t.Run("When long order and short order's base asset quantity is same", func(t *testing.T) {
-					//Add 2 long orders
-					db, lotp, lop := setupDependencies(t)
-					longOrders := make([]limitorders.LimitOrder, 0)
-					longOrder1 := getLongOrder()
-					longOrders = append(longOrders, longOrder1)
-					longOrder2 := getLongOrder()
-					longOrder2.Signature = []byte("Here is a 2nd long order")
-					longOrders = append(longOrders, longOrder2)
-
-					// Add 2 short orders
-					shortOrder1 := getShortOrder()
-					shortOrders := make([]limitorders.LimitOrder, 0)
-					shortOrders = append(shortOrders, shortOrder1)
-					shortOrder2 := getShortOrder()
-					shortOrder2.Signature = []byte("Here is a 2nd short order")
-					shortOrders = append(shortOrders, shortOrder2)
-
-					db.On("GetLongOrders").Return(longOrders)
-					db.On("GetShortOrders").Return(shortOrders)
-					lotp.On("PurgeLocalTx").Return(nil)
-					fillAmount1 := uint(longOrder1.BaseAssetQuantity)
-					fillAmount2 := uint(longOrder2.BaseAssetQuantity)
-					lotp.On("ExecuteMatchedOrdersTx", longOrder1, shortOrder1, fillAmount1).Return(nil)
-					lotp.On("ExecuteMatchedOrdersTx", longOrder2, shortOrder2, fillAmount2).Return(nil)
-					lop.RunMatchingEngine()
-					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder1, shortOrder1, fillAmount1)
-					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder2, shortOrder2, fillAmount2)
-				})
-				t.Run("When long order and short order's base asset quantity is different", func(t *testing.T) {
-					db, lotp, lop := setupDependencies(t)
-					//Add 2 long orders with half base asset quantity of short order
-					longOrders := make([]limitorders.LimitOrder, 0)
-					longOrder := getLongOrder()
-					longOrder.BaseAssetQuantity = 20
-					longOrder.FilledBaseAssetQuantity = 5
-					longOrders = append(longOrders, longOrder)
-
-					// Add 2 short orders
-					shortOrder := getShortOrder()
-					shortOrder.BaseAssetQuantity = -30
-					shortOrder.FilledBaseAssetQuantity = -15
-					shortOrders := make([]limitorders.LimitOrder, 0)
-					shortOrders = append(shortOrders, shortOrder)
-
-					fillAmount := uint(longOrder.BaseAssetQuantity - longOrder.FilledBaseAssetQuantity)
-					db.On("GetLongOrders").Return(longOrders)
-					db.On("GetShortOrders").Return(shortOrders)
-					lotp.On("PurgeLocalTx").Return(nil)
-					lotp.On("ExecuteMatchedOrdersTx", longOrder, shortOrder, fillAmount).Return(nil)
-					lop.RunMatchingEngine()
-					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder, shortOrder, fillAmount)
-				})
-			})
-			t.Run("When long order and short order's unfulfilled quantity is not same", func(t *testing.T) {
+		t.Run("When short orders are present in db", func(t *testing.T) {
+			t.Run("when longOrder.price < shortOrder.price, matching engine does not call ExecuteMatchedOrders", func(t *testing.T) {
 				db, lotp, lop := setupDependencies(t)
 				longOrders := make([]limitorders.LimitOrder, 0)
-				longOrder1 := getLongOrder()
-				longOrder1.BaseAssetQuantity = 20
-				longOrder1.FilledBaseAssetQuantity = 5
-				longOrder2 := getLongOrder()
-				longOrder2.BaseAssetQuantity = 40
-				longOrder2.FilledBaseAssetQuantity = 0
-				longOrder2.Signature = []byte("Here is a 2nd long order")
-				longOrder3 := getLongOrder()
-				longOrder3.BaseAssetQuantity = 10
-				longOrder3.FilledBaseAssetQuantity = 3
-				longOrder3.Signature = []byte("Here is a 3rd long order")
-				longOrders = append(longOrders, longOrder1, longOrder2, longOrder3)
-
-				// Add 2 short orders
 				shortOrders := make([]limitorders.LimitOrder, 0)
-				shortOrder1 := getShortOrder()
-				shortOrder1.BaseAssetQuantity = -30
-				shortOrder1.FilledBaseAssetQuantity = -2
-				shortOrder2 := getShortOrder()
-				shortOrder2.BaseAssetQuantity = -50
-				shortOrder2.FilledBaseAssetQuantity = -20
-				shortOrder2.Signature = []byte("Here is a 2nd short order")
-				shortOrder3 := getShortOrder()
-				shortOrder3.BaseAssetQuantity = -20
-				shortOrder3.FilledBaseAssetQuantity = -10
-				shortOrder3.Signature = []byte("Here is a 3rd short order")
-				shortOrders = append(shortOrders, shortOrder1, shortOrder2, shortOrder3)
-
-				lotp.On("ExecuteMatchedOrdersTx", mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(5)
-
+				longOrder := getLongOrder()
+				longOrders = append(longOrders, longOrder)
+				shortOrder := getShortOrder()
+				shortOrder.Price = shortOrder.Price + 2
+				shortOrders = append(shortOrders, shortOrder)
 				db.On("GetLongOrders").Return(longOrders)
 				db.On("GetShortOrders").Return(shortOrders)
 				lotp.On("PurgeLocalTx").Return(nil)
 				lop.RunMatchingEngine()
+				lotp.AssertNotCalled(t, "ExecuteMatchedOrdersTx", mock.Anything, mock.Anything, mock.Anything)
+			})
+			t.Run("when longOrder.price >= shortOrder.price", func(t *testing.T) {
+				t.Run("When long order and short order's unfulfilled quantity is same", func(t *testing.T) {
+					t.Run("When long order and short order's base asset quantity is same, matching engine calls ExecuteMatchedOrders", func(t *testing.T) {
+						//Add 2 long orders
+						db, lotp, lop := setupDependencies(t)
+						longOrder1 := getLongOrder()
+						longOrder2 := getLongOrder()
+						longOrder2.Price = longOrder1.Price + 1
+						longOrder2.Signature = []byte("Here is a 2nd long order")
+						//slice sorted by higher price
+						longOrders := []limitorders.LimitOrder{longOrder2, longOrder1}
 
-				//During 1st  matching iteration
-				longOrder1UnfulfilledQuantity := longOrder1.BaseAssetQuantity - longOrder1.FilledBaseAssetQuantity
-				shortOrder1UnfulfilledQuantity := shortOrder1.BaseAssetQuantity - shortOrder1.FilledBaseAssetQuantity
-				fillAmount := uint(math.Min(float64(longOrder1UnfulfilledQuantity), float64(-(shortOrder1UnfulfilledQuantity))))
-				lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder1, shortOrder1, fillAmount)
-				//After 1st matching iteration longOrder1 has been matched fully but shortOrder1 has not
-				longOrder1.FilledBaseAssetQuantity = longOrder1.FilledBaseAssetQuantity + int(fillAmount)
-				shortOrder1.FilledBaseAssetQuantity = shortOrder1.FilledBaseAssetQuantity - int(fillAmount)
+						// Add 2 short orders
+						shortOrder1 := getShortOrder()
+						shortOrder2 := getShortOrder()
+						shortOrder2.Price = shortOrder1.Price - 1
+						shortOrder2.Signature = []byte("Here is a 2nd short order")
+						//slice sorted by lower price
+						shortOrders := []limitorders.LimitOrder{shortOrder2, shortOrder1}
 
-				//During 2nd iteration longOrder2 with be matched with shortOrder1
-				longOrder2UnfulfilledQuantity := longOrder2.BaseAssetQuantity - longOrder2.FilledBaseAssetQuantity
-				shortOrder1UnfulfilledQuantity = shortOrder1.BaseAssetQuantity - shortOrder1.FilledBaseAssetQuantity
-				fillAmount = uint(math.Min(float64(longOrder2UnfulfilledQuantity), float64(-(shortOrder1UnfulfilledQuantity))))
-				lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder2, shortOrder1, fillAmount)
-				//After 2nd matching iteration shortOrder1 has been matched fully but longOrder2 has not
-				longOrder2.FilledBaseAssetQuantity = longOrder2.FilledBaseAssetQuantity + int(fillAmount)
-				shortOrder1.FilledBaseAssetQuantity = shortOrder1.FilledBaseAssetQuantity - int(fillAmount)
+						db.On("GetLongOrders").Return(longOrders)
+						db.On("GetShortOrders").Return(shortOrders)
+						lotp.On("PurgeLocalTx").Return(nil)
+						fillAmount1 := uint(longOrder1.BaseAssetQuantity)
+						fillAmount2 := uint(longOrder2.BaseAssetQuantity)
+						lotp.On("ExecuteMatchedOrdersTx", longOrder1, shortOrder1, fillAmount1).Return(nil)
+						lotp.On("ExecuteMatchedOrdersTx", longOrder2, shortOrder2, fillAmount2).Return(nil)
+						lop.RunMatchingEngine()
+						lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder1, shortOrder1, fillAmount1)
+						lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder2, shortOrder2, fillAmount2)
+					})
+					t.Run("When long order and short order's base asset quantity is different, matching engine calls ExecuteMatchedOrders", func(t *testing.T) {
+						db, lotp, lop := setupDependencies(t)
 
-				//During 3rd iteration longOrder2 with be matched with shortOrder2
-				longOrder2UnfulfilledQuantity = longOrder2.BaseAssetQuantity - longOrder2.FilledBaseAssetQuantity
-				shortOrder2UnfulfilledQuantity := shortOrder2.BaseAssetQuantity - shortOrder2.FilledBaseAssetQuantity
-				fillAmount = uint(math.Min(float64(longOrder2UnfulfilledQuantity), float64(-(shortOrder2UnfulfilledQuantity))))
-				lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder2, shortOrder2, fillAmount)
-				//After 3rd matching iteration longOrder2 has been matched fully but shortOrder2 has not
-				longOrder2.FilledBaseAssetQuantity = longOrder2.FilledBaseAssetQuantity + int(fillAmount)
-				shortOrder2.FilledBaseAssetQuantity = shortOrder2.FilledBaseAssetQuantity - int(fillAmount)
+						longOrder := getLongOrder()
+						longOrder.BaseAssetQuantity = 20
+						longOrder.FilledBaseAssetQuantity = 5
+						longOrders := []limitorders.LimitOrder{longOrder}
 
-				//So during 4th iteration longOrder3 with be matched with shortOrder2
-				longOrder3UnfulfilledQuantity := longOrder3.BaseAssetQuantity - longOrder3.FilledBaseAssetQuantity
-				shortOrder2UnfulfilledQuantity = shortOrder2.BaseAssetQuantity - shortOrder2.FilledBaseAssetQuantity
-				fillAmount = uint(math.Min(float64(longOrder3UnfulfilledQuantity), float64(-(shortOrder2UnfulfilledQuantity))))
-				lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder3, shortOrder2, fillAmount)
-				//After 4rd matching iteration shortOrder2 has been matched fully but longOrder3 has not
-				longOrder3.FilledBaseAssetQuantity = longOrder3.FilledBaseAssetQuantity + int(fillAmount)
-				shortOrder2.FilledBaseAssetQuantity = shortOrder2.FilledBaseAssetQuantity - int(fillAmount)
+						shortOrder := getShortOrder()
+						shortOrder.BaseAssetQuantity = -30
+						shortOrder.FilledBaseAssetQuantity = -15
+						shortOrders := []limitorders.LimitOrder{shortOrder}
 
-				//So during 5th iteration longOrder3 with be matched with shortOrder3
-				longOrder3UnfulfilledQuantity = longOrder3.BaseAssetQuantity - longOrder3.FilledBaseAssetQuantity
-				shortOrder3UnfulfilledQuantity := shortOrder3.BaseAssetQuantity - shortOrder3.FilledBaseAssetQuantity
-				fillAmount = uint(math.Min(float64(longOrder3UnfulfilledQuantity), float64(-(shortOrder3UnfulfilledQuantity))))
-				lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder3, shortOrder3, fillAmount)
+						fillAmount := uint(longOrder.BaseAssetQuantity - longOrder.FilledBaseAssetQuantity)
+						db.On("GetLongOrders").Return(longOrders)
+						db.On("GetShortOrders").Return(shortOrders)
+						lotp.On("PurgeLocalTx").Return(nil)
+						lotp.On("ExecuteMatchedOrdersTx", longOrder, shortOrder, fillAmount).Return(nil)
+						lop.RunMatchingEngine()
+						lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder, shortOrder, fillAmount)
+					})
+				})
+				t.Run("When long order and short order's unfulfilled quantity is not same, matching engine calls ExecuteMatchedOrders", func(t *testing.T) {
+					db, lotp, lop := setupDependencies(t)
+					longOrder1 := getLongOrder()
+					longOrder1.BaseAssetQuantity = 20
+					longOrder1.FilledBaseAssetQuantity = 5
+					longOrder2 := getLongOrder()
+					longOrder2.BaseAssetQuantity = 40
+					longOrder2.FilledBaseAssetQuantity = 0
+					longOrder2.Price = longOrder1.Price + 1
+					longOrder2.Signature = []byte("Here is a 2nd long order")
+					longOrder3 := getLongOrder()
+					longOrder3.BaseAssetQuantity = 10
+					longOrder3.FilledBaseAssetQuantity = 3
+					longOrder3.Signature = []byte("Here is a 3rd long order")
+					longOrder3.Price = longOrder2.Price + 1
+					//slice sorted by higher price
+					longOrders := []limitorders.LimitOrder{longOrder3, longOrder2, longOrder1}
+
+					// Add 2 short orders
+					shortOrder1 := getShortOrder()
+					shortOrder1.BaseAssetQuantity = -30
+					shortOrder1.FilledBaseAssetQuantity = -2
+					shortOrder2 := getShortOrder()
+					shortOrder2.BaseAssetQuantity = -50
+					shortOrder2.FilledBaseAssetQuantity = -20
+					shortOrder2.Price = shortOrder1.Price - 1
+					shortOrder2.Signature = []byte("Here is a 2nd short order")
+					shortOrder3 := getShortOrder()
+					shortOrder3.BaseAssetQuantity = -20
+					shortOrder3.FilledBaseAssetQuantity = -10
+					shortOrder3.Price = shortOrder2.Price - 1
+					shortOrder3.Signature = []byte("Here is a 3rd short order")
+					//slice sorted by lower price
+					shortOrders := []limitorders.LimitOrder{shortOrder3, shortOrder2, shortOrder1}
+
+					lotp.On("ExecuteMatchedOrdersTx", mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(5)
+
+					db.On("GetLongOrders").Return(longOrders)
+					db.On("GetShortOrders").Return(shortOrders)
+					lotp.On("PurgeLocalTx").Return(nil)
+					lop.RunMatchingEngine()
+
+					//During 1st  matching iteration
+					fillAmount := uint(math.Min(float64(getUnFilledBaseAssetQuantity(longOrder3)), float64(-(getUnFilledBaseAssetQuantity(shortOrder3)))))
+					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder3, shortOrder3, fillAmount)
+					//After 1st matching iteration longOrder3 has been matched fully but shortOrder3 has not
+					longOrder3.FilledBaseAssetQuantity = longOrder3.FilledBaseAssetQuantity + int(fillAmount)
+					shortOrder3.FilledBaseAssetQuantity = shortOrder3.FilledBaseAssetQuantity - int(fillAmount)
+
+					//During 2nd iteration longOrder2 with be matched with shortOrder3
+					fillAmount = uint(math.Min(float64(getUnFilledBaseAssetQuantity(longOrder2)), float64(-(getUnFilledBaseAssetQuantity(shortOrder3)))))
+					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder2, shortOrder3, fillAmount)
+					//After 2nd matching iteration shortOrder3 has been matched fully but longOrder2 has not
+					longOrder2.FilledBaseAssetQuantity = longOrder2.FilledBaseAssetQuantity + int(fillAmount)
+					shortOrder3.FilledBaseAssetQuantity = shortOrder3.FilledBaseAssetQuantity - int(fillAmount)
+
+					//During 3rd iteration longOrder2 with be matched with shortOrder2
+					fillAmount = uint(math.Min(float64(getUnFilledBaseAssetQuantity(longOrder2)), float64(-(getUnFilledBaseAssetQuantity(shortOrder2)))))
+					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder2, shortOrder2, fillAmount)
+					//After 3rd matching iteration shortOrder2 has been matched fully but longOrder2 has not
+					longOrder2.FilledBaseAssetQuantity = longOrder2.FilledBaseAssetQuantity + int(fillAmount)
+					shortOrder2.FilledBaseAssetQuantity = shortOrder2.FilledBaseAssetQuantity - int(fillAmount)
+
+					//During 4th iteration longOrder2 with be matched with shortOrder1
+					fillAmount = uint(math.Min(float64(getUnFilledBaseAssetQuantity(longOrder2)), float64(-(getUnFilledBaseAssetQuantity(shortOrder1)))))
+					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder2, shortOrder1, fillAmount)
+					//After 4rd matching iteration shortOrder2 has been matched fully but longOrder3 has not
+					longOrder2.FilledBaseAssetQuantity = longOrder2.FilledBaseAssetQuantity + int(fillAmount)
+					shortOrder1.FilledBaseAssetQuantity = shortOrder1.FilledBaseAssetQuantity - int(fillAmount)
+
+					//During 5th iteration longOrder1 with be matched with shortOrder1
+					fillAmount = uint(math.Min(float64(getUnFilledBaseAssetQuantity(longOrder1)), float64(-(getUnFilledBaseAssetQuantity(shortOrder1)))))
+					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder1, shortOrder1, fillAmount)
+				})
 			})
 		})
 	})
@@ -261,13 +252,14 @@ func getLongOrder() limitorders.LimitOrder {
 
 func createLimitOrder(positionType string, userAddress string, baseAssetQuantity int, price float64, status string, salt int64, signature []byte, blockNumber uint64) limitorders.LimitOrder {
 	return limitorders.LimitOrder{
-		PositionType:      positionType,
-		UserAddress:       userAddress,
-		BaseAssetQuantity: baseAssetQuantity,
-		Price:             price,
-		Status:            status,
-		Salt:              salt,
-		Signature:         signature,
-		BlockNumber:       blockNumber,
+		PositionType:            positionType,
+		UserAddress:             userAddress,
+		BaseAssetQuantity:       baseAssetQuantity,
+		FilledBaseAssetQuantity: 0,
+		Price:                   price,
+		Status:                  status,
+		Salt:                    salt,
+		Signature:               signature,
+		BlockNumber:             blockNumber,
 	}
 }

--- a/plugin/evm/limit_order_test.go
+++ b/plugin/evm/limit_order_test.go
@@ -199,37 +199,60 @@ func TestRunMatchingEngine(t *testing.T) {
 					lotp.On("PurgeLocalTx").Return(nil)
 					lop.RunMatchingEngine()
 
-					//During 1st  matching iteration
+					// During 1st  matching iteration
+					// orderbook: Longs: [(22.01,10,3), (21.01,40,0), (20.01,20,5)], Shorts: [(18.01,-20,-10), (19.01,-50,-20), (20.01,-30,-2)]
 					fillAmount := uint(math.Min(float64(getUnFilledBaseAssetQuantity(longOrder3)), float64(-(getUnFilledBaseAssetQuantity(shortOrder3)))))
+					assert.Equal(t, uint(7), fillAmount)
 					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder3, shortOrder3, fillAmount)
 					//After 1st matching iteration longOrder3 has been matched fully but shortOrder3 has not
-					longOrder3.FilledBaseAssetQuantity = longOrder3.FilledBaseAssetQuantity + int(fillAmount)
-					shortOrder3.FilledBaseAssetQuantity = shortOrder3.FilledBaseAssetQuantity - int(fillAmount)
+					longOrder3.FilledBaseAssetQuantity += int(fillAmount)
+					assert.Equal(t, int(10), longOrder3.FilledBaseAssetQuantity)
+					shortOrder3.FilledBaseAssetQuantity -= int(fillAmount)
+					assert.Equal(t, int(-17), shortOrder3.FilledBaseAssetQuantity)
 
-					//During 2nd iteration longOrder2 with be matched with shortOrder3
+					// During 2nd iteration longOrder2 with be matched with shortOrder3
+					// orderbook: Longs: [(22.01,10,10), (21.01,40,0), (20.01,20,5)], Shorts: [(18.01,-20,-17), (19.01,-50,-20), (20.01,-30,-2)]
 					fillAmount = uint(math.Min(float64(getUnFilledBaseAssetQuantity(longOrder2)), float64(-(getUnFilledBaseAssetQuantity(shortOrder3)))))
+					assert.Equal(t, uint(3), fillAmount)
 					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder2, shortOrder3, fillAmount)
 					//After 2nd matching iteration shortOrder3 has been matched fully but longOrder2 has not
-					longOrder2.FilledBaseAssetQuantity = longOrder2.FilledBaseAssetQuantity + int(fillAmount)
-					shortOrder3.FilledBaseAssetQuantity = shortOrder3.FilledBaseAssetQuantity - int(fillAmount)
+					longOrder2.FilledBaseAssetQuantity += int(fillAmount)
+					assert.Equal(t, int(3), longOrder2.FilledBaseAssetQuantity)
+					shortOrder3.FilledBaseAssetQuantity -= int(fillAmount)
+					assert.Equal(t, int(-20), shortOrder2.FilledBaseAssetQuantity)
 
-					//During 3rd iteration longOrder2 with be matched with shortOrder2
+					// During 3rd iteration longOrder2 with be matched with shortOrder2
+					// orderbook: Longs: [(22.01,10,10), (21.01,40,3), (20.01,20,5)], Shorts: [(18.01,-20,-20), (19.01,-50,-20), (20.01,-30,-2)]
 					fillAmount = uint(math.Min(float64(getUnFilledBaseAssetQuantity(longOrder2)), float64(-(getUnFilledBaseAssetQuantity(shortOrder2)))))
+					assert.Equal(t, uint(30), fillAmount)
 					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder2, shortOrder2, fillAmount)
 					//After 3rd matching iteration shortOrder2 has been matched fully but longOrder2 has not
-					longOrder2.FilledBaseAssetQuantity = longOrder2.FilledBaseAssetQuantity + int(fillAmount)
-					shortOrder2.FilledBaseAssetQuantity = shortOrder2.FilledBaseAssetQuantity - int(fillAmount)
+					longOrder2.FilledBaseAssetQuantity += int(fillAmount)
+					assert.Equal(t, int(33), longOrder2.FilledBaseAssetQuantity)
+					shortOrder2.FilledBaseAssetQuantity -= int(fillAmount)
+					assert.Equal(t, int(-50), shortOrder2.FilledBaseAssetQuantity)
 
-					//During 4th iteration longOrder2 with be matched with shortOrder1
+					// During 4th iteration longOrder2 with be matched with shortOrder1
+					// orderbook: Longs: [(22.01,10,10), (21.01,40,33), (20.01,20,5)], Shorts: [(18.01,-20,-20), (19.01,-50,-50), (20.01,-30,-2)]
 					fillAmount = uint(math.Min(float64(getUnFilledBaseAssetQuantity(longOrder2)), float64(-(getUnFilledBaseAssetQuantity(shortOrder1)))))
+					assert.Equal(t, uint(7), fillAmount)
 					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder2, shortOrder1, fillAmount)
 					//After 4rd matching iteration shortOrder2 has been matched fully but longOrder3 has not
-					longOrder2.FilledBaseAssetQuantity = longOrder2.FilledBaseAssetQuantity + int(fillAmount)
-					shortOrder1.FilledBaseAssetQuantity = shortOrder1.FilledBaseAssetQuantity - int(fillAmount)
+					longOrder2.FilledBaseAssetQuantity += int(fillAmount)
+					assert.Equal(t, int(40), longOrder2.FilledBaseAssetQuantity)
+					shortOrder1.FilledBaseAssetQuantity -= int(fillAmount)
+					assert.Equal(t, int(-9), shortOrder1.FilledBaseAssetQuantity)
 
-					//During 5th iteration longOrder1 with be matched with shortOrder1
+					// During 5th iteration longOrder1 with be matched with shortOrder1
+					// orderbook: Longs: [(22.01,10,10), (21.01,40,40), (20.01,20,5)], Shorts: [(18.01,-20,-20), (19.01,-50,-50), (20.01,-30,-9)]
 					fillAmount = uint(math.Min(float64(getUnFilledBaseAssetQuantity(longOrder1)), float64(-(getUnFilledBaseAssetQuantity(shortOrder1)))))
+					assert.Equal(t, uint(15), fillAmount)
 					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder1, shortOrder1, fillAmount)
+
+					longOrder1.FilledBaseAssetQuantity += int(fillAmount)
+					assert.Equal(t, int(20), longOrder1.FilledBaseAssetQuantity)
+					shortOrder1.FilledBaseAssetQuantity -= int(fillAmount)
+					assert.Equal(t, int(-24), shortOrder1.FilledBaseAssetQuantity)
 				})
 			})
 		})

--- a/plugin/evm/limit_order_test.go
+++ b/plugin/evm/limit_order_test.go
@@ -289,29 +289,41 @@ func createLimitOrder(positionType string, userAddress string, baseAssetQuantity
 
 func TestGetUnfilledBaseAssetQuantity(t *testing.T) {
 	t.Run("When limit FilledBaseAssetQuantity is zero, it returns BaseAssetQuantity", func(t *testing.T) {
-		longOrder := getLongOrder()
-		longOrderFilledBaseQuantity := 0
-		longOrder.FilledBaseAssetQuantity = longOrderFilledBaseQuantity
-		expectedUnFilledForLongOrder := longOrder.BaseAssetQuantity - longOrderFilledBaseQuantity
+		baseAssetQuantityLongOrder := 10
+		signature := []byte("Here is a long order")
+		salt := time.Now().Unix()
+		longOrder := createLimitOrder("long", "0x22Bb736b64A0b4D4081E103f83bccF864F0404aa", baseAssetQuantityLongOrder, 20.01, "unfulfilled", salt, signature, 2)
+		longOrder.FilledBaseAssetQuantity = 0
+		//baseAssetQuantityLongOrder - filledBaseAssetQuantity
+		expectedUnFilledForLongOrder := 10
 		assert.Equal(t, expectedUnFilledForLongOrder, getUnFilledBaseAssetQuantity(longOrder))
 
-		shortOrder := getShortOrder()
-		shortOrderFilledBaseQuantity := 0
-		shortOrder.FilledBaseAssetQuantity = shortOrderFilledBaseQuantity
-		expectedUnFilledForShortOrder := shortOrder.BaseAssetQuantity - shortOrderFilledBaseQuantity
+		signature = []byte("Here is a short order")
+		salt = time.Now().Unix()
+		baseAssetQuantityShortOrder := -10
+		shortOrder := createLimitOrder("short", "0x22Bb736b64A0b4D4081E103f83bccF864F0404aa", baseAssetQuantityShortOrder, 20.01, "unfulfilled", salt, signature, 2)
+		shortOrder.FilledBaseAssetQuantity = 0
+		//baseAssetQuantityLongOrder - filledBaseAssetQuantity
+		expectedUnFilledForShortOrder := -10
 		assert.Equal(t, expectedUnFilledForShortOrder, getUnFilledBaseAssetQuantity(shortOrder))
 	})
 	t.Run("When limit FilledBaseAssetQuantity is not zero, it returns BaseAssetQuantity - FilledBaseAssetQuantity", func(t *testing.T) {
-		longOrder := getLongOrder()
-		longOrderFilledBaseQuantity := 5
-		longOrder.FilledBaseAssetQuantity = longOrderFilledBaseQuantity
-		expectedUnFilledForLongOrder := longOrder.BaseAssetQuantity - longOrderFilledBaseQuantity
+		baseAssetQuantityLongOrder := 10
+		signature := []byte("Here is a long order")
+		salt := time.Now().Unix()
+		longOrder := createLimitOrder("long", "0x22Bb736b64A0b4D4081E103f83bccF864F0404aa", baseAssetQuantityLongOrder, 20.01, "unfulfilled", salt, signature, 2)
+		longOrder.FilledBaseAssetQuantity = 5
+		//baseAssetQuantityLongOrder - filledBaseAssetQuantity
+		expectedUnFilledForLongOrder := 5
 		assert.Equal(t, expectedUnFilledForLongOrder, getUnFilledBaseAssetQuantity(longOrder))
 
-		shortOrder := getShortOrder()
-		shortOrderFilledBaseQuantity := -5
-		shortOrder.FilledBaseAssetQuantity = shortOrderFilledBaseQuantity
-		expectedUnFilledForShortOrder := shortOrder.BaseAssetQuantity - shortOrderFilledBaseQuantity
+		signature = []byte("Here is a short order")
+		salt = time.Now().Unix()
+		baseAssetQuantityShortOrder := -10
+		shortOrder := createLimitOrder("short", "0x22Bb736b64A0b4D4081E103f83bccF864F0404aa", baseAssetQuantityShortOrder, 20.01, "unfulfilled", salt, signature, 2)
+		shortOrder.FilledBaseAssetQuantity = -5
+		//baseAssetQuantityLongOrder - filledBaseAssetQuantity
+		expectedUnFilledForShortOrder := -5
 		assert.Equal(t, expectedUnFilledForShortOrder, getUnFilledBaseAssetQuantity(shortOrder))
 	})
 }


### PR DESCRIPTION
## Why this should be merged
In Matching engine the condition for matching long and short order was that they should have same price. We want to allow orders to match if longOrder.Price >= shortOrder.Price.
As longOrders are sorted by price from high to low and shortOrders are sorted by price from low to high
If price check conditions fails anytime it does not makes sense to run further iterations, so i also added logic to exit loop in that case.

## How this works
Changed the price check from longOrder.Price == shortOrder.Price to longOrder.Price >= shortOrder.Price
also exit loop if condition(longOrder.Price >= shortOrder.Price ) fails.

## How this was tested
I have updated unit tests which test this.
