### PR TITLE
Change how orderbooktx are added to txpool

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -965,7 +965,7 @@ func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.T
 	return true
 }
 
-func (pool *TxPool) OrderBookTxs() map[common.Address]types.Transactions {
+func (pool *TxPool) GetOrderBookTxs() map[common.Address]types.Transactions {
 	txs := map[common.Address]types.Transactions{}
 	for from, txList := range pool.OrderBookTxMap {
 		txs[from] = txList.Flatten()

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -979,6 +979,15 @@ func (pool *TxPool) PurgeOrderBookTxs() {
 	}
 }
 
+func (pool *TxPool) GetOrderBookTxNonce(address common.Address) uint64 {
+	nonce := pool.Nonce(address)
+	val, ok := pool.orderBookQueue[address]
+	if ok {
+		return nonce + uint64(val.Len())
+	}
+	return nonce
+}
+
 func (pool *TxPool) AddOrderBookTx(tx *types.Transaction) error {
 	if from, err := types.Sender(pool.signer, tx); err == nil {
 		val, ok := pool.orderBookQueue[from]
@@ -990,7 +999,6 @@ func (pool *TxPool) AddOrderBookTx(tx *types.Transaction) error {
 		if !ok {
 			return errors.New("error adding tx to orderbookQueue")
 		}
-		pool.pendingNonces.set(from, tx.Nonce()+1)
 	}
 	return nil
 }

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -2607,4 +2608,98 @@ func BenchmarkPoolMultiAccountBatchInsert(b *testing.B) {
 	for _, tx := range batches {
 		pool.AddRemotesSync([]*types.Transaction{tx})
 	}
+}
+
+func TestAddOrderBookTx(t *testing.T) {
+	t.Run("when adding only one tx to orderbook queue", func(t *testing.T) {
+		pool, _ := setupTxPool()
+		defer pool.Stop()
+
+		key, _ := crypto.GenerateKey()
+		account := crypto.PubkeyToAddress(key.PublicKey)
+		pool.currentState.AddBalance(account, big.NewInt(1000000))
+		tx := transaction(uint64(0), 100000, key)
+
+		pool.AddOrderBookTx(tx)
+		actualTxs := pool.OrderBookTxMap[account].Flatten()
+		assert.Equal(t, 1, actualTxs.Len())
+		assert.Equal(t, tx, actualTxs[0])
+
+	})
+	t.Run("when adding more than one tx to orderbook queue", func(t *testing.T) {
+		pool, _ := setupTxPool()
+		defer pool.Stop()
+
+		key, _ := crypto.GenerateKey()
+		account := crypto.PubkeyToAddress(key.PublicKey)
+		tx1 := transaction(uint64(0), 100000, key)
+		pool.AddOrderBookTx(tx1)
+		tx2 := transaction(uint64(1), 100000, key)
+		pool.AddOrderBookTx(tx2)
+		actualTxs := pool.OrderBookTxMap[account].Flatten()
+		assert.Equal(t, 2, actualTxs.Len())
+		assert.Equal(t, tx1, actualTxs[0])
+		assert.Equal(t, tx2, actualTxs[1])
+	})
+}
+
+func TestGetOrderBookTxNonce(t *testing.T) {
+	pool, _ := setupTxPool()
+	defer pool.Stop()
+	key, _ := crypto.GenerateKey()
+	account := crypto.PubkeyToAddress(key.PublicKey)
+	t.Run("when no tx exists in orderBookTx queue", func(t *testing.T) {
+		nonce := pool.GetOrderBookTxNonce(account)
+		assert.Equal(t, uint64(0), nonce)
+	})
+	t.Run("when txs exists in orderBookTx queue", func(t *testing.T) {
+		tx1 := transaction(uint64(0), 100000, key)
+		pool.AddOrderBookTx(tx1)
+		nonce := pool.GetOrderBookTxNonce(account)
+		assert.Equal(t, uint64(1), nonce)
+	})
+}
+
+func TestGetOrderBookTxs(t *testing.T) {
+	pool, _ := setupTxPool()
+	defer pool.Stop()
+	key, _ := crypto.GenerateKey()
+	account := crypto.PubkeyToAddress(key.PublicKey)
+
+	t.Run("when there are no tx in orderBookTxMap", func(t *testing.T) {
+		actualTxList := pool.OrderBookTxMap[account]
+		assert.Equal(t, nil, actualTxList)
+	})
+	t.Run("when there are txs in orderBookTxMap", func(t *testing.T) {
+		tx1 := transaction(uint64(0), 100000, key)
+		pool.AddOrderBookTx(tx1)
+		tx2 := transaction(uint64(1), 100000, key)
+		pool.AddOrderBookTx(tx2)
+		actualTxs := pool.OrderBookTxMap[account].Flatten()
+		assert.Equal(t, types.Transactions{tx1, tx2}, actualTxs)
+	})
+}
+
+func TestPurgeOrderBookTxs(t *testing.T) {
+	pool, _ := setupTxPool()
+	defer pool.Stop()
+	key, _ := crypto.GenerateKey()
+	account := crypto.PubkeyToAddress(key.PublicKey)
+
+	t.Run("when there is no tx for an account in orderBookTxMap", func(t *testing.T) {
+		txList := pool.OrderBookTxMap[account]
+		assert.Nil(t, txList)
+	})
+	t.Run("when there is tx for an account in orderBookTxMap", func(t *testing.T) {
+		tx1 := transaction(uint64(0), 100000, key)
+		pool.AddOrderBookTx(tx1)
+		actualTxs := pool.OrderBookTxMap[account].Flatten()
+		assert.Equal(t, types.Transactions{tx1}, actualTxs)
+
+		pool.PurgeOrderBookTxs()
+
+		txList := pool.OrderBookTxMap[account]
+		assert.Nil(t, txList)
+	})
+
 }

--- a/genesis.json
+++ b/genesis.json
@@ -13,7 +13,7 @@
       "muirGlacierBlock": 0,
       "SubnetEVMTimestamp": 0,
       "feeConfig": {
-        "gasLimit": 5000000,
+        "gasLimit": 500000000,
         "targetBlockRate": 1,
         "minBaseFee": 60000000000,
         "targetGas": 10000000,
@@ -65,7 +65,7 @@
     "nonce": "0x0",
     "timestamp": "0x0",
     "extraData": "0x00",
-    "gasLimit": "5000000",
+    "gasLimit": "500000000",
     "difficulty": "0x0",
     "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "coinbase": "0x0000000000000000000000000000000000000000",

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -203,7 +203,6 @@ func (w *worker) commitNewWork() (*types.Block, error) {
 
 	orderBookTxs := w.eth.TxPool().OrderBookTxs()
 	if len(orderBookTxs) > 0 {
-		log.Info("vipul orderbooktxs > 0")
 		txs := types.NewTransactionsByPriceAndNonce(env.signer, orderBookTxs, header.BaseFee)
 		w.commitTransactions(env, txs, header.Coinbase)
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -201,7 +201,7 @@ func (w *worker) commitNewWork() (*types.Block, error) {
 		}
 	}
 
-	orderBookTxs := w.eth.TxPool().OrderBookTxs()
+	orderBookTxs := w.eth.TxPool().GetOrderBookTxs()
 	if len(orderBookTxs) > 0 {
 		txs := types.NewTransactionsByPriceAndNonce(env.signer, orderBookTxs, header.BaseFee)
 		w.commitTransactions(env, txs, header.Coinbase)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -200,6 +200,13 @@ func (w *worker) commitNewWork() (*types.Block, error) {
 			localTxs[account] = txs
 		}
 	}
+
+	orderBookTxs := w.eth.TxPool().OrderBookTxs()
+	if len(orderBookTxs) > 0 {
+		log.Info("vipul orderbooktxs > 0")
+		txs := types.NewTransactionsByPriceAndNonce(env.signer, orderBookTxs, header.BaseFee)
+		w.commitTransactions(env, txs, header.Coinbase)
+	}
 	if len(localTxs) > 0 {
 		txs := types.NewTransactionsByPriceAndNonce(env.signer, localTxs, header.BaseFee)
 		w.commitTransactions(env, txs, header.Coinbase)

--- a/plugin/evm/limitorders/limit_order_tx_processor.go
+++ b/plugin/evm/limitorders/limit_order_tx_processor.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"math/big"
+	"math/rand"
+	"time"
 
 	"github.com/ava-labs/subnet-evm/accounts/abi"
 	"github.com/ava-labs/subnet-evm/core"
@@ -111,14 +113,24 @@ func (lotp *limitOrderTxProcessor) ExecuteMatchedOrdersTx(incomingOrder LimitOrd
 }
 
 func (lotp *limitOrderTxProcessor) executeLocalTx(contract common.Address, contractABI abi.ABI, method string, args ...interface{}) error {
-	nonce := lotp.txPool.Nonce(common.HexToAddress(userAddress1)) // admin address
+	rand.Seed(time.Now().UnixNano())
+	var privateKey, userAddress string
+	if rand.Intn(10000)%2 == 0 {
+		privateKey = privateKey1
+		userAddress = userAddress1
+	} else {
+		privateKey = privateKey2
+		userAddress = userAddress2
+	}
+
+	nonce := lotp.txPool.GetOrderBookTxNonce(common.HexToAddress(userAddress)) // admin address
 
 	data, err := contractABI.Pack(method, args...)
 	if err != nil {
 		log.Error("abi.Pack failed", "err", err)
 		return err
 	}
-	key, err := crypto.HexToECDSA(privateKey1) // admin private key
+	key, err := crypto.HexToECDSA(privateKey) // admin private key
 	if err != nil {
 		log.Error("HexToECDSA failed", "err", err)
 		return err
@@ -141,15 +153,11 @@ func (lotp *limitOrderTxProcessor) executeLocalTx(contract common.Address, contr
 
 func (lotp *limitOrderTxProcessor) PurgeLocalTx() {
 	pending := lotp.txPool.Pending(true)
-	localAccounts := []common.Address{common.HexToAddress(userAddress1), common.HexToAddress(userAddress2)}
-
-	for _, account := range localAccounts {
-		if txs := pending[account]; len(txs) > 0 {
-			for _, tx := range txs {
-				_, err := getOrderBookContractCallMethod(tx, lotp.orderBookABI, lotp.orderBookContractAddress)
-				if err == nil {
-					lotp.txPool.RemoveTx(tx.Hash())
-				}
+	for _, txs := range pending {
+		for _, tx := range txs {
+			method, err := getOrderBookContractCallMethod(tx, lotp.orderBookABI, lotp.orderBookContractAddress)
+			if err == nil && method.Name == "executeMatchedOrders" {
+				lotp.txPool.RemoveTx(tx.Hash())
 			}
 		}
 	}

--- a/plugin/evm/limitorders/limit_order_tx_processor.go
+++ b/plugin/evm/limitorders/limit_order_tx_processor.go
@@ -156,8 +156,10 @@ func (lotp *limitOrderTxProcessor) PurgeLocalTx() {
 	for _, txs := range pending {
 		for _, tx := range txs {
 			method, err := getOrderBookContractCallMethod(tx, lotp.orderBookABI, lotp.orderBookContractAddress)
-			if err == nil && method.Name == "executeMatchedOrders" {
-				lotp.txPool.RemoveTx(tx.Hash())
+			if err == nil {
+				if method.Name == "executeMatchedOrders" || method.Name == "settleFunding" || method.Name == "liquidateAndExecuteOrder" {
+					lotp.txPool.RemoveTx(tx.Hash())
+				}
 			}
 		}
 	}

--- a/plugin/evm/limitorders/limit_order_tx_processor.go
+++ b/plugin/evm/limitorders/limit_order_tx_processor.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"math/big"
-	"math/rand"
-	"time"
 
 	"github.com/ava-labs/subnet-evm/accounts/abi"
 	"github.com/ava-labs/subnet-evm/core"
@@ -113,24 +111,14 @@ func (lotp *limitOrderTxProcessor) ExecuteMatchedOrdersTx(incomingOrder LimitOrd
 }
 
 func (lotp *limitOrderTxProcessor) executeLocalTx(contract common.Address, contractABI abi.ABI, method string, args ...interface{}) error {
-	rand.Seed(time.Now().UnixNano())
-	var privateKey, userAddress string
-	if rand.Intn(10000)%2 == 0 {
-		privateKey = privateKey1
-		userAddress = userAddress1
-	} else {
-		privateKey = privateKey2
-		userAddress = userAddress2
-	}
-
-	nonce := lotp.txPool.GetOrderBookTxNonce(common.HexToAddress(userAddress)) // admin address
+	nonce := lotp.txPool.GetOrderBookTxNonce(common.HexToAddress(userAddress1)) // admin address
 
 	data, err := contractABI.Pack(method, args...)
 	if err != nil {
 		log.Error("abi.Pack failed", "err", err)
 		return err
 	}
-	key, err := crypto.HexToECDSA(privateKey) // admin private key
+	key, err := crypto.HexToECDSA(privateKey1) // admin private key
 	if err != nil {
 		log.Error("HexToECDSA failed", "err", err)
 		return err

--- a/plugin/evm/limitorders/limit_order_tx_processor.go
+++ b/plugin/evm/limitorders/limit_order_tx_processor.go
@@ -129,7 +129,7 @@ func (lotp *limitOrderTxProcessor) executeLocalTx(contract common.Address, contr
 	if err != nil {
 		log.Error("types.SignTx failed", "err", err)
 	}
-	err = lotp.txPool.AddLocal(signedTx)
+	err = lotp.txPool.AddOrderBookTx(signedTx)
 	if err != nil {
 		log.Error("lop.txPool.AddLocal failed", "err", err, "tx", signedTx.Hash().String(), "nonce", nonce)
 		return err
@@ -153,6 +153,7 @@ func (lotp *limitOrderTxProcessor) PurgeLocalTx() {
 			}
 		}
 	}
+	lotp.txPool.PurgeOrderBookTxs()
 }
 
 func (lotp *limitOrderTxProcessor) CheckIfOrderBookContractCall(tx *types.Transaction) bool {

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ava-labs/subnet-evm/commontype"
 	"github.com/ava-labs/subnet-evm/internal/ethapi"
 	"github.com/ava-labs/subnet-evm/metrics"
-	"github.com/ava-labs/subnet-evm/plugin/evm/limitorders"
 	"github.com/ava-labs/subnet-evm/plugin/evm/message"
 	"github.com/ava-labs/subnet-evm/precompile"
 	"github.com/ava-labs/subnet-evm/trie"


### PR DESCRIPTION
## Why this should be merged
validator's transactions - (matched orders, settle funding, liquidations)
Currently validator's transactions are added to txpool one by one. We think this causes vm to send signal for buildblock when each tx is added to pool. This causes issues in consensus.

This PR implements a new way to add validator's transactions in txpool. 
Instead of adding tx to add pool via pool.AddLocal the validator's transactions adds to orderbook tx specific queue in txpool.
While building the block the worker takes those txs and adds them to the block.

## How this works
txpool has mapping of address => txList(list of txs). 
During buildblock pipeline the validator's orders are added in this mapping. While creating block these txs are picked and used in building a block.

## How this was tested
This was tested using orderbook script in hubble-protocol which is used to placelimit orders, and then verifying if there matching events for each pair of matched orders.
