### PR TITLE
add orderbook_newOrderBookData subscription api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,4 @@ contract-examples/dynamic_rpc.json
 plugins/evm/hubble.db
 
 *.bin
-local_status
+local_status.sh

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ contract-examples/dynamic_rpc.json
 plugins/evm/hubble.db
 
 *.bin
+local_status

--- a/plugin/evm/limitorders/service.go
+++ b/plugin/evm/limitorders/service.go
@@ -9,16 +9,22 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ava-labs/subnet-evm/core"
+	"github.com/ava-labs/subnet-evm/eth"
+	"github.com/ava-labs/subnet-evm/rpc"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/event"
 )
 
 type OrderBookAPI struct {
-	db LimitOrderDatabase
+	db      LimitOrderDatabase
+	backend *eth.EthAPIBackend
 }
 
-func NewOrderBookAPI(database LimitOrderDatabase) *OrderBookAPI {
+func NewOrderBookAPI(database LimitOrderDatabase, backend *eth.EthAPIBackend) *OrderBookAPI {
 	return &OrderBookAPI{
-		db: database,
+		db:      database,
+		backend: backend,
 	}
 }
 
@@ -100,4 +106,40 @@ func (api *OrderBookAPI) GetOpenOrders(ctx context.Context, trader string) OpenO
 	}
 
 	return OpenOrdersResponse{Orders: traderOrders}
+}
+
+// NewOrderBookData send a notification each time a new (header) block is appended to the chain.
+func (api *OrderBookAPI) NewOrderBookData(ctx context.Context) (*rpc.Subscription, error) {
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+
+	rpcSub := notifier.CreateSubscription()
+
+	go func() {
+		var (
+			headers    = make(chan core.ChainHeadEvent)
+			headersSub event.Subscription
+		)
+
+		headersSub = api.backend.SubscribeChainHeadEvent(headers)
+		defer headersSub.Unsubscribe()
+
+		for {
+			select {
+			case <-headers:
+				orderBookData := api.GetDetailedOrderBookData(ctx)
+				notifier.Notify(rpcSub.ID, orderBookData)
+			case <-rpcSub.Err():
+				headersSub.Unsubscribe()
+				return
+			case <-notifier.Closed():
+				headersSub.Unsubscribe()
+				return
+			}
+		}
+	}()
+
+	return rpcSub, nil
 }

--- a/plugin/evm/limitorders/service.go
+++ b/plugin/evm/limitorders/service.go
@@ -108,8 +108,8 @@ func (api *OrderBookAPI) GetOpenOrders(ctx context.Context, trader string) OpenO
 	return OpenOrdersResponse{Orders: traderOrders}
 }
 
-// NewOrderBookData send a notification each time a new (header) block is appended to the chain.
-func (api *OrderBookAPI) NewOrderBookData(ctx context.Context) (*rpc.Subscription, error) {
+// NewOrderBookState send a notification each time a new (header) block is appended to the chain.
+func (api *OrderBookAPI) NewOrderBookState(ctx context.Context) (*rpc.Subscription, error) {
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
@@ -130,7 +130,7 @@ func (api *OrderBookAPI) NewOrderBookData(ctx context.Context) (*rpc.Subscriptio
 			select {
 			case <-headers:
 				orderBookData := api.GetDetailedOrderBookData(ctx)
-				notifier.Notify(rpcSub.ID, orderBookData)
+				notifier.Notify(rpcSub.ID, &orderBookData)
 			case <-rpcSub.Err():
 				headersSub.Unsubscribe()
 				return


### PR DESCRIPTION
## Why this should be merged
It implements an api which can be subscribed to get OrderBook state events which are emitted whenever chainHead event is emitted.

## How this works

## How this was tested
$ wscat -c ws://127.0.0.1:9650/ext/bc/2iMfN47WzfzSSXCAbbAp8Rf5U2xjncQiNvbHavvrJCatuaxsat/ws
Connected (press CTRL+C to quit)
> {"jsonrpc":  "2.0",  "id":  1,  "method":  "orderbook_subscribe",  "params":  ["newOrderBookData"]}
we received the orderbook state whenever new block was mined.

## How is this documented
