### PR TITLE
add logs to hubblefeed if head block is replaced with another during reorg

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -995,6 +995,10 @@ func (bc *BlockChain) setPreference(block *types.Block) error {
 	// Send a ChainHeadEvent if we end up altering
 	// the head block. Many internal aysnc processes rely on
 	// receiving these events (i.e. the TxPool).
+	logs := bc.collectLogs(block.Hash(), false)
+	if len(logs) > 0 {
+		bc.hubbleFeed.Send(logs)
+	}
 	bc.chainHeadFeed.Send(ChainHeadEvent{Block: block})
 	return nil
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -995,11 +995,16 @@ func (bc *BlockChain) setPreference(block *types.Block) error {
 	// Send a ChainHeadEvent if we end up altering
 	// the head block. Many internal aysnc processes rely on
 	// receiving these events (i.e. the TxPool).
+	bc.chainHeadFeed.Send(ChainHeadEvent{Block: block})
+
+	// when a reorg is triggered, rebirth logs for the new head are not emitted
+	// this can be confirmed in blockchain .reorg, where the loop for collecting rebirth logs is written as:
+	// for i := len(newChain) - 1; i >= 1; i-- {
+	// hence we emit them here
 	logs := bc.collectLogs(block.Hash(), false)
 	if len(logs) > 0 {
 		bc.hubbleFeed.Send(logs)
 	}
-	bc.chainHeadFeed.Send(ChainHeadEvent{Block: block})
 	return nil
 }
 


### PR DESCRIPTION
## Why this should be merged
Lets say 
1.  node a,b,c,d,e have accepted block no 53
2. Now we make a transactions for place orders. 
3. Node a starts to build block A(no 54) . It will 
- include those orders in tx and make a block
- verify the block(insert block in database as new head as it is a new block)
- hubblefeed receives the logs from the block A and adds orders in memory_database
4. Now lets say another block B wins in election instead of block A
5. what happens then is
- verify is called on node A for block B, which adds the block to the blockchain, but as block number this block B (no 54) is same block number of block A(no 54), there is no head event. 
- after verify if set preferences is called with block B, that triggers a reorg
- block A is removed from the chain and its logs are sent in deletedLogs
- blockB is added as new head

Our issue is that we dont have logs from blockB in the hubblefeed in the above situation. 
In real world we dont receive limit order placed events from block no 54 as original block A which was head is reverted and new block B 's logs are not being consumed as of now.

## How this works
With this commit whenever this happens and block B is updated as newHead. We sent the logs of that block B in hubble feed.

## How this was tested

## How is this documented