### PR TITLE
calculate baseFee dynamically for validator transactions

### DIFF
--- a/plugin/evm/limitorders/limit_order_tx_processor.go
+++ b/plugin/evm/limitorders/limit_order_tx_processor.go
@@ -139,7 +139,7 @@ func (lotp *limitOrderTxProcessor) executeLocalTx(contract common.Address, contr
 		baseFeeEstimate = big.NewInt(0).Abs(lotp.backend.CurrentHeader().BaseFee)
 		log.Info("Error in calculating updated bassFee, using last header's baseFee", "baseFeeEstimate", baseFeeEstimate)
 	}
-	tx := types.NewTransaction(nonce, contract, big.NewInt(0), 5000000, baseFeeEstimate, data)
+	tx := types.NewTransaction(nonce, contract, big.NewInt(0), 1000000, baseFeeEstimate, data)
 	signer := types.NewLondonSigner(lotp.backend.ChainConfig().ChainID)
 	signedTx, err := types.SignTx(tx, signer, key)
 	if err != nil {

--- a/plugin/evm/limitorders/limit_order_tx_processor.go
+++ b/plugin/evm/limitorders/limit_order_tx_processor.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/eth"
 	"github.com/ava-labs/subnet-evm/internal/ethapi"
-	"github.com/ava-labs/subnet-evm/params"
 	"github.com/ava-labs/subnet-evm/rpc"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -49,7 +48,6 @@ type limitOrderTxProcessor struct {
 	backend                      *eth.EthAPIBackend
 	validatorAddress             common.Address
 	validatorPrivateKey          string
-	chainConfig                  *params.ChainConfig
 }
 
 // Order type is copy of Order struct defined in Orderbook contract
@@ -61,7 +59,7 @@ type Order struct {
 	Salt              *big.Int       `json:"salt"`
 }
 
-func NewLimitOrderTxProcessor(txPool *core.TxPool, memoryDb LimitOrderDatabase, backend *eth.EthAPIBackend, chainConfig *params.ChainConfig) LimitOrderTxProcessor {
+func NewLimitOrderTxProcessor(txPool *core.TxPool, memoryDb LimitOrderDatabase, backend *eth.EthAPIBackend) LimitOrderTxProcessor {
 	orderBookABI, err := abi.FromSolidityJson(string(orderBookAbi))
 	if err != nil {
 		panic(err)
@@ -97,7 +95,6 @@ func NewLimitOrderTxProcessor(txPool *core.TxPool, memoryDb LimitOrderDatabase, 
 		backend:                      backend,
 		validatorAddress:             validatorAddress,
 		validatorPrivateKey:          validatorPrivateKey,
-		chainConfig:                  chainConfig,
 	}
 }
 

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -973,7 +973,7 @@ func attachEthService(handler *rpc.Server, apis []rpc.API, names []string) error
 
 func (vm *VM) NewLimitOrderProcesser() LimitOrderProcesser {
 	memoryDb := limitorders.NewInMemoryDatabase()
-	lotp := limitorders.NewLimitOrderTxProcessor(vm.txPool, memoryDb, vm.eth.APIBackend, vm.chainConfig)
+	lotp := limitorders.NewLimitOrderTxProcessor(vm.txPool, memoryDb, vm.eth.APIBackend)
 
 	return NewLimitOrderProcesser(
 		vm.ctx,

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -973,7 +973,7 @@ func attachEthService(handler *rpc.Server, apis []rpc.API, names []string) error
 
 func (vm *VM) NewLimitOrderProcesser() LimitOrderProcesser {
 	memoryDb := limitorders.NewInMemoryDatabase()
-	lotp := limitorders.NewLimitOrderTxProcessor(vm.txPool, memoryDb, vm.eth.APIBackend)
+	lotp := limitorders.NewLimitOrderTxProcessor(vm.txPool, memoryDb, vm.eth.APIBackend, vm.chainConfig)
 
 	return NewLimitOrderProcesser(
 		vm.ctx,


### PR DESCRIPTION
## Why this should be merged
Validators make transaction for matching orders, liquidations and to settle funding . The gas fee we pay for these txs is hard coded above baseFee right now. Sometimes when baseFee goes high enough, the validator txs stop going through.  Thus the gas fee for validator txs should be dynamic.

## How this works
This PR dynamically calculates gas fee validator has to pay for its txs and then creates a tx with that gas fee.
## How this was tested

## How is this documented
