### PR TITLE
Use current time in funding payments

### DIFF
--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -19,7 +19,7 @@ import (
 
 type LimitOrderProcesser interface {
 	ListenAndProcessTransactions()
-	RunBuildBlockPipeline(lastBlockTime uint64)
+	RunBuildBlockPipeline()
 	GetOrderBookAPI() *limitorders.OrderBookAPI
 }
 
@@ -90,8 +90,8 @@ func (lop *limitOrderProcesser) ListenAndProcessTransactions() {
 	lop.listenAndStoreLimitOrderTransactions()
 }
 
-func (lop *limitOrderProcesser) RunBuildBlockPipeline(lastBlockTime uint64) {
-	lop.buildBlockPipeline.Run(lastBlockTime)
+func (lop *limitOrderProcesser) RunBuildBlockPipeline() {
+	lop.buildBlockPipeline.Run()
 }
 
 func (lop *limitOrderProcesser) GetOrderBookAPI() *limitorders.OrderBookAPI {

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -660,7 +660,7 @@ func (vm *VM) buildBlockWithContext(ctx context.Context, proposerVMBlockCtx *blo
 		ProposerVMBlockCtx: proposerVMBlockCtx,
 	}
 
-	vm.limitOrderProcesser.RunBuildBlockPipeline(vm.miner.GetLastBlockTime())
+	vm.limitOrderProcesser.RunBuildBlockPipeline()
 	block, err := vm.miner.GenerateBlock(predicateCtx)
 	vm.builder.handleGenerateBlock()
 	if err != nil {


### PR DESCRIPTION
## Why this should be merged
Since it’s quite possible that last block was built several minutes ago, we might fail to trigger a funding tx. So using the current time is better here.

## How this was tested
Locally
