### PR TITLE
Hubblenext fixes

### DIFF
--- a/plugin/evm/limitorders/build_block_pipeline.go
+++ b/plugin/evm/limitorders/build_block_pipeline.go
@@ -63,12 +63,14 @@ func (pipeline *BuildBlockPipeline) cancelOrders(cancellableOrders map[common.Ad
 	cancellableOrderIds := map[common.Hash]struct{}{}
 	// @todo: if there are too many cancellable orders, they might not fit in a single block. Need to adjust for that.
 	for _, orderIds := range cancellableOrders {
-		err := pipeline.lotp.ExecuteOrderCancel(orderIds)
-		if err != nil {
-			log.Error("Error in ExecuteOrderCancel", "orderIds", formatHashSlice(orderIds), "err", err)
-		} else {
-			for _, orderId := range orderIds {
-				cancellableOrderIds[orderId] = struct{}{}
+		if len(orderIds) > 0 {
+			err := pipeline.lotp.ExecuteOrderCancel(orderIds)
+			if err != nil {
+				log.Error("Error in ExecuteOrderCancel", "orderIds", formatHashSlice(orderIds), "err", err)
+			} else {
+				for _, orderId := range orderIds {
+					cancellableOrderIds[orderId] = struct{}{}
+				}
 			}
 		}
 	}

--- a/plugin/evm/limitorders/memory_database.go
+++ b/plugin/evm/limitorders/memory_database.go
@@ -497,6 +497,10 @@ func (db *InMemoryDatabase) determineOrdersToCancel(addr common.Address, trader 
 		// cancel orders until available margin is positive
 		ordersToCancel[addr] = []common.Hash{}
 		for _, order := range traderOrders {
+			// cannot cancel ReduceOnly orders because no margin is reserved for them
+			if order.ReduceOnly {
+				continue
+			}
 			ordersToCancel[addr] = append(ordersToCancel[addr], order.Id)
 			orderNotional := big.NewInt(0).Abs(big.NewInt(0).Div(big.NewInt(0).Mul(order.GetUnFilledBaseAssetQuantity(), order.Price), _1e18)) // | size * current price |
 			marginReleased := divideByBasePrecision(big.NewInt(0).Mul(orderNotional, minAllowableMargin))

--- a/plugin/evm/limitorders/memory_database.go
+++ b/plugin/evm/limitorders/memory_database.go
@@ -150,6 +150,7 @@ type LimitOrderDatabase interface {
 	SetOrderStatus(orderId common.Hash, status Status, blockNumber uint64) error
 	RevertLastStatus(orderId common.Hash) error
 	GetNaughtyTraders(oraclePrices map[Market]*big.Int) ([]LiquidablePosition, map[common.Address][]common.Hash)
+	GetOpenOrdersForTrader(trader common.Address) []LimitOrder
 }
 
 type InMemoryDatabase struct {
@@ -427,6 +428,13 @@ func (db *InMemoryDatabase) GetAllTraders() map[common.Address]Trader {
 		traderMap[address] = *trader
 	}
 	return traderMap
+}
+
+func (db *InMemoryDatabase) GetOpenOrdersForTrader(trader common.Address) []LimitOrder {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	return db.getTraderOrders(trader)
 }
 
 func determinePositionToLiquidate(trader *Trader, addr common.Address, marginFraction *big.Int) LiquidablePosition {

--- a/plugin/evm/limitorders/memory_database.go
+++ b/plugin/evm/limitorders/memory_database.go
@@ -109,6 +109,16 @@ func (order LimitOrder) String() string {
 	return fmt.Sprintf("LimitOrder: Market: %v, PositionType: %v, UserAddress: %v, BaseAssetQuantity: %s, FilledBaseAssetQuantity: %s, Salt: %v, Price: %s, ReduceOnly: %v, Signature: %v, BlockNumber: %s", order.Market, order.PositionType, order.UserAddress, prettifyScaledBigInt(order.BaseAssetQuantity, 18), prettifyScaledBigInt(order.FilledBaseAssetQuantity, 18), order.Salt, prettifyScaledBigInt(order.Price, 6), order.ReduceOnly, hex.EncodeToString(order.Signature), order.BlockNumber)
 }
 
+func (order LimitOrder) ToOrderMin() OrderMin {
+	return OrderMin{
+		Market:  order.Market,
+		Price:   order.Price.String(),
+		Size:    order.GetUnFilledBaseAssetQuantity().String(),
+		Signer:  order.UserAddress,
+		OrderId: order.Id.String(),
+	}
+}
+
 type Position struct {
 	OpenNotional         *big.Int `json:"open_notional"`
 	Size                 *big.Int `json:"size"`

--- a/plugin/evm/limitorders/mocks.go
+++ b/plugin/evm/limitorders/mocks.go
@@ -112,6 +112,10 @@ func (db *MockLimitOrderDatabase) GetOrderBookData() InMemoryDatabase {
 	return *&InMemoryDatabase{}
 }
 
+func (db *MockLimitOrderDatabase) GetOpenOrdersForTrader(trader common.Address) []LimitOrder {
+	return nil
+}
+
 type MockLimitOrderTxProcessor struct {
 	mock.Mock
 }

--- a/plugin/evm/limitorders/service_test.go
+++ b/plugin/evm/limitorders/service_test.go
@@ -45,6 +45,9 @@ func TestAggregatedOrderBook(t *testing.T) {
 			},
 		}
 		assert.Equal(t, expectedAggregatedOrderBookState, *response)
+
+		orderbook, _ := service.GetOrderBook(ctx, "0")
+		assert.Equal(t, 4, len(orderbook.Orders))
 	})
 	t.Run("when event is the first event after subscribe", func(t *testing.T) {
 		t.Run("when orderbook has no orders", func(t *testing.T) {

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -648,6 +648,7 @@ func (vm *VM) buildBlock(ctx context.Context) (snowman.Block, error) {
 }
 
 func (vm *VM) buildBlockWithContext(ctx context.Context, proposerVMBlockCtx *block.Context) (snowman.Block, error) {
+	log.Info("#### buildBlockWithContext called")
 	if proposerVMBlockCtx != nil {
 		log.Debug("Building block with context", "pChainBlockHeight", proposerVMBlockCtx.PChainHeight)
 	} else {


### PR DESCRIPTION
## Concurrent map misuse
https://tip.golang.org/doc/go1.8#mapiter
Causes the program to crash. Fixed by returning array of orders for API functions.

## ReduceOnly orders getting cancelled
ReduceOnly orders shouldn't be cancelled cuz they don't release any margin

## Improper mutex usages
Remove potential causes of mutex deadlock. Also converted the mutex to a pointer
https://groups.google.com/g/golang-nuts/c/o-2N5wc8JcI
https://groups.google.com/g/golang-nuts/c/imxjBLNJ9OY?pli=1
https://stackoverflow.com/a/37242475/2485594

## How this was tested
On local and hubblenext
