### PR TITLE
Fix integration tests

### DIFF
--- a/plugin/evm/limitorders/config.go
+++ b/plugin/evm/limitorders/config.go
@@ -7,5 +7,5 @@ var (
 	maintenanceMargin    = big.NewInt(1e5)
 	spreadRatioThreshold = big.NewInt(1e6)
 	maxLiquidationRatio  = big.NewInt(25 * 1e4) // 25%
-	minSizeRequirement   = big.NewInt(0).Mul(big.NewInt(5), _1e18)
+	minSizeRequirement   = big.NewInt(1e16)
 )

--- a/scripts/check_local_health.sh
+++ b/scripts/check_local_health.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+
+source local_status.sh
+
+apis=(
+  "http://127.0.0.1:9650/ext/bc/$CHAIN_ID/rpc"
+  "http://127.0.0.1:9652/ext/bc/$CHAIN_ID/rpc"
+  "http://127.0.0.1:9654/ext/bc/$CHAIN_ID/rpc"
+  "http://127.0.0.1:9656/ext/bc/$CHAIN_ID/rpc"
+  "http://127.0.0.1:9658/ext/bc/$CHAIN_ID/rpc"
+)
+
+# Flag to track if any API took longer than 1 second to respond
+error_flag=false
+
+# Loop through each API endpoint
+for api in "${apis[@]}"; do
+  # Call the API endpoint with a timeout of 1 second
+  if ! curl --connect-timeout 1 --max-time 1 -s "$api" > /dev/null; then
+    echo "API $api did not respond within 1 second."
+    error_flag=true
+  fi
+done
+
+# Check if any API took longer to respond
+if [ "$error_flag" = true ]; then
+  echo "Error: One or more APIs did not respond within 1 second."
+else
+  echo "OK: All APIs responded within 1 second."
+fi

--- a/scripts/show_logs.sh
+++ b/scripts/show_logs.sh
@@ -3,4 +3,4 @@
 set -e
 
 source ./scripts/utils.sh
-showLogs "$1"
+showLogs "$1" "$2"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -35,7 +35,11 @@ function showLogs() {
             -ci yellow --label "[node4]" -I $(echo $LOGS_PATH | sed -e 's/<i>/4/g')/$CHAIN_ID.log \
             -ci cyan --label "[node5]" -I $(echo $LOGS_PATH | sed -e 's/<i>/5/g')/$CHAIN_ID.log
     else
-        tail -f "${LOGS_PATH/<i>/$1}/$CHAIN_ID.log"
+        if [ -z "$2" ]; then
+            tail -f "${LOGS_PATH/<i>/$1}/$CHAIN_ID.log"
+        else
+            grep --color=auto -i "$2" "${LOGS_PATH/<i>/$1}/$CHAIN_ID.log"
+        fi
     fi
 
 }

--- a/tests/orderbook/abi/AMM.json
+++ b/tests/orderbook/abi/AMM.json
@@ -1,0 +1,871 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_clearingHouse",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "price",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "openNotional",
+                "type": "uint256"
+            },
+            {
+                "internalType": "int256",
+                "name": "size",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "margin",
+                "type": "int256"
+            }
+        ],
+        "name": "_getPositionMetadata",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "notionalPos",
+                "type": "uint256"
+            },
+            {
+                "internalType": "int256",
+                "name": "uPnl",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "marginFraction",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_oracle",
+                "type": "address"
+            }
+        ],
+        "name": "changeOracle",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "clearingHouse",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "cumulativePremiumFraction",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "fundingBufferPeriod",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "fundingPeriod",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "trader",
+                "type": "address"
+            }
+        ],
+        "name": "getNotionalPositionAndUnrealizedPnl",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "notionalPosition",
+                "type": "uint256"
+            },
+            {
+                "internalType": "int256",
+                "name": "unrealizedPnl",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int256",
+                "name": "positionSize",
+                "type": "int256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "openNotional",
+                "type": "uint256"
+            },
+            {
+                "internalType": "int256",
+                "name": "unrealizedPnl",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "baseAssetQuantity",
+                "type": "int256"
+            }
+        ],
+        "name": "getOpenNotionalWhileReducingPosition",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "remainOpenNotional",
+                "type": "uint256"
+            },
+            {
+                "internalType": "int256",
+                "name": "realizedPnl",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "trader",
+                "type": "address"
+            },
+            {
+                "internalType": "int256",
+                "name": "margin",
+                "type": "int256"
+            },
+            {
+                "internalType": "enum IClearingHouse.Mode",
+                "name": "mode",
+                "type": "uint8"
+            }
+        ],
+        "name": "getOptimalPnl",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "notionalPosition",
+                "type": "uint256"
+            },
+            {
+                "internalType": "int256",
+                "name": "unrealizedPnl",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "trader",
+                "type": "address"
+            }
+        ],
+        "name": "getPendingFundingPayment",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "takerFundingPayment",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "latestCumulativePremiumFraction",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getSnapshotLen",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_intervalInSeconds",
+                "type": "uint256"
+            }
+        ],
+        "name": "getTwapPrice",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getUnderlyingPrice",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_intervalInSeconds",
+                "type": "uint256"
+            }
+        ],
+        "name": "getUnderlyingTwapPrice",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "governance",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "_name",
+                "type": "string"
+            },
+            {
+                "internalType": "address",
+                "name": "_underlyingAsset",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "_oracle",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_minSizeRequirement",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "_governance",
+                "type": "address"
+            }
+        ],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "lastPrice",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "trader",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "price",
+                "type": "uint256"
+            },
+            {
+                "internalType": "int256",
+                "name": "fillAmount",
+                "type": "int256"
+            }
+        ],
+        "name": "liquidatePosition",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "realizedPnl",
+                "type": "int256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "quoteAsset",
+                "type": "uint256"
+            },
+            {
+                "internalType": "int256",
+                "name": "size",
+                "type": "int256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "openNotional",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "longOpenInterestNotional",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "maxFundingRate",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "maxLiquidationPriceSpread",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "maxLiquidationRatio",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "maxOracleSpreadRatio",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "minSizeRequirement",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "name",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "nextFundingTime",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "openInterestNotional",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "ammIndex",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "trader",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "int256",
+                        "name": "baseAssetQuantity",
+                        "type": "int256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "price",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "salt",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "reduceOnly",
+                        "type": "bool"
+                    }
+                ],
+                "internalType": "struct IOrderBook.Order",
+                "name": "order",
+                "type": "tuple"
+            },
+            {
+                "internalType": "int256",
+                "name": "fillAmount",
+                "type": "int256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "fulfillPrice",
+                "type": "uint256"
+            }
+        ],
+        "name": "openPosition",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "realizedPnl",
+                "type": "int256"
+            },
+            {
+                "internalType": "bool",
+                "name": "isPositionIncreased",
+                "type": "bool"
+            },
+            {
+                "internalType": "int256",
+                "name": "size",
+                "type": "int256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "openNotional",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "oracle",
+        "outputs": [
+            {
+                "internalType": "contract IOracle",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "positions",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "size",
+                "type": "int256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "openNotional",
+                "type": "uint256"
+            },
+            {
+                "internalType": "int256",
+                "name": "lastPremiumFraction",
+                "type": "int256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "liquidationThreshold",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "name": "reserveSnapshots",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "lastPrice",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "timestamp",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "blockNumber",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_fundingBufferPeriod",
+                "type": "uint256"
+            }
+        ],
+        "name": "setFundingBufferPeriod",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_governance",
+                "type": "address"
+            }
+        ],
+        "name": "setGovernace",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_maxLiquidationRatio",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_maxLiquidationPriceSpread",
+                "type": "uint256"
+            }
+        ],
+        "name": "setLiquidationParams",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int256",
+                "name": "_maxFundingRate",
+                "type": "int256"
+            }
+        ],
+        "name": "setMaxFundingRate",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_minSizeRequirement",
+                "type": "uint256"
+            }
+        ],
+        "name": "setMinSizeRequirement",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_maxOracleSpreadRatio",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "name": "setPriceSpreadParams",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "settleFunding",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "premiumFraction",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "underlyingPrice",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "",
+                "type": "int256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "shortOpenInterestNotional",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "spotPriceTwapInterval",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "startFunding",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "underlyingAsset",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "trader",
+                "type": "address"
+            }
+        ],
+        "name": "updatePosition",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "fundingPayment",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "latestCumulativePremiumFraction",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]

--- a/tests/orderbook/abi/ClearingHouse.json
+++ b/tests/orderbook/abi/ClearingHouse.json
@@ -1,16 +1,5 @@
 [
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_trustedForwarder",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
         "anonymous": false,
         "inputs": [
             {
@@ -146,7 +135,7 @@
             {
                 "indexed": false,
                 "internalType": "uint256",
-                "name": "quoteAsset",
+                "name": "price",
                 "type": "uint256"
             },
             {
@@ -166,6 +155,12 @@
                 "internalType": "uint256",
                 "name": "openNotional",
                 "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "int256",
+                "name": "fee",
+                "type": "int256"
             },
             {
                 "indexed": false,
@@ -201,7 +196,7 @@
             {
                 "indexed": false,
                 "internalType": "uint256",
-                "name": "quoteAsset",
+                "name": "price",
                 "type": "uint256"
             },
             {
@@ -221,6 +216,12 @@
                 "internalType": "uint256",
                 "name": "openNotional",
                 "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "int256",
+                "name": "fee",
+                "type": "int256"
             },
             {
                 "indexed": false,
@@ -383,25 +384,6 @@
                 "internalType": "address",
                 "name": "trader",
                 "type": "address"
-            }
-        ],
-        "name": "getMarginFraction",
-        "outputs": [
-            {
-                "internalType": "int256",
-                "name": "",
-                "type": "int256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
             },
             {
                 "internalType": "bool",
@@ -425,6 +407,30 @@
                 "internalType": "int256",
                 "name": "margin",
                 "type": "int256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int256",
+                "name": "baseAssetQuantity",
+                "type": "int256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "price",
+                "type": "uint256"
+            }
+        ],
+        "name": "getRequiredMargin",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "requiredMargin",
+                "type": "uint256"
             }
         ],
         "stateMutability": "view",
@@ -478,6 +484,19 @@
                 "internalType": "int256",
                 "name": "unrealizedPnl",
                 "type": "int256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getUnderlyingPrice",
+        "outputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "prices",
+                "type": "uint256[]"
             }
         ],
         "stateMutability": "view",
@@ -569,25 +588,6 @@
     {
         "inputs": [
             {
-                "internalType": "address",
-                "name": "forwarder",
-                "type": "address"
-            }
-        ],
-        "name": "isTrustedForwarder",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
                 "components": [
                     {
                         "internalType": "uint256",
@@ -613,6 +613,11 @@
                         "internalType": "uint256",
                         "name": "salt",
                         "type": "uint256"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "reduceOnly",
+                        "type": "bool"
                     }
                 ],
                 "internalType": "struct IOrderBook.Order",
@@ -632,9 +637,9 @@
                         "type": "uint256"
                     },
                     {
-                        "internalType": "bool",
-                        "name": "isMakerOrder",
-                        "type": "bool"
+                        "internalType": "enum IOrderBook.OrderExecutionMode",
+                        "name": "mode",
+                        "type": "uint8"
                     }
                 ],
                 "internalType": "struct IOrderBook.MatchInfo",
@@ -721,9 +726,9 @@
         "name": "makerFee",
         "outputs": [
             {
-                "internalType": "uint256",
+                "internalType": "int256",
                 "name": "",
-                "type": "uint256"
+                "type": "int256"
             }
         ],
         "stateMutability": "view",
@@ -783,6 +788,11 @@
                         "internalType": "uint256",
                         "name": "salt",
                         "type": "uint256"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "reduceOnly",
+                        "type": "bool"
                     }
                 ],
                 "internalType": "struct IOrderBook.Order[2]",
@@ -802,9 +812,9 @@
                         "type": "uint256"
                     },
                     {
-                        "internalType": "bool",
-                        "name": "isMakerOrder",
-                        "type": "bool"
+                        "internalType": "enum IOrderBook.OrderExecutionMode",
+                        "name": "mode",
+                        "type": "uint8"
                     }
                 ],
                 "internalType": "struct IOrderBook.MatchInfo[2]",
@@ -855,6 +865,11 @@
                         "internalType": "uint256",
                         "name": "salt",
                         "type": "uint256"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "reduceOnly",
+                        "type": "bool"
                     }
                 ],
                 "internalType": "struct IOrderBook.Order",
@@ -872,9 +887,9 @@
                 "type": "uint256"
             },
             {
-                "internalType": "bool",
-                "name": "isMakerOrder",
-                "type": "bool"
+                "internalType": "enum IOrderBook.OrderExecutionMode",
+                "name": "mode",
+                "type": "uint8"
             }
         ],
         "name": "openPosition",
@@ -954,14 +969,14 @@
                 "type": "int256"
             },
             {
-                "internalType": "uint256",
+                "internalType": "int256",
                 "name": "_takerFee",
-                "type": "uint256"
+                "type": "int256"
             },
             {
-                "internalType": "uint256",
+                "internalType": "int256",
                 "name": "_makerFee",
-                "type": "uint256"
+                "type": "int256"
             },
             {
                 "internalType": "uint256",
@@ -996,9 +1011,9 @@
         "name": "takerFee",
         "outputs": [
             {
-                "internalType": "uint256",
+                "internalType": "int256",
                 "name": "",
-                "type": "uint256"
+                "type": "int256"
             }
         ],
         "stateMutability": "view",

--- a/tests/orderbook/abi/MarginAccount.json
+++ b/tests/orderbook/abi/MarginAccount.json
@@ -99,6 +99,25 @@
                 "type": "address"
             },
             {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "MarginReleased",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "trader",
+                "type": "address"
+            },
+            {
                 "indexed": true,
                 "internalType": "uint256",
                 "name": "idx",
@@ -118,6 +137,25 @@
             }
         ],
         "name": "MarginRemoved",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "trader",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "MarginReserved",
         "type": "event"
     },
     {
@@ -282,6 +320,25 @@
                 "internalType": "uint256",
                 "name": "",
                 "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "trader",
+                "type": "address"
+            }
+        ],
+        "name": "getAvailableMargin",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "availableMargin",
+                "type": "int256"
             }
         ],
         "stateMutability": "view",
@@ -553,6 +610,19 @@
     },
     {
         "inputs": [],
+        "name": "orderBook",
+        "outputs": [
+            {
+                "internalType": "contract IOrderBook",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
         "name": "pause",
         "outputs": [],
         "stateMutability": "nonpayable",
@@ -572,19 +642,6 @@
         "type": "function"
     },
     {
-        "inputs": [],
-        "name": "portfolioManager",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
         "inputs": [
             {
                 "internalType": "address",
@@ -598,6 +655,24 @@
             }
         ],
         "name": "realizePnL",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "trader",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "releaseMargin",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"
@@ -642,18 +717,32 @@
             },
             {
                 "internalType": "uint256",
-                "name": "idx",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
                 "name": "amount",
                 "type": "uint256"
             }
         ],
-        "name": "removeMarginFor",
+        "name": "reserveMargin",
         "outputs": [],
         "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "reservedMargin",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
         "type": "function"
     },
     {
@@ -665,19 +754,6 @@
             }
         ],
         "name": "setGovernace",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_portfolioManager",
-                "type": "address"
-            }
-        ],
-        "name": "setPortfolioManager",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"

--- a/tests/orderbook/abi/MarginAccountHelper.json
+++ b/tests/orderbook/abi/MarginAccountHelper.json
@@ -1,56 +1,56 @@
 [
     {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_marginAccount",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "_vusd",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "_wavax",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "constructor"
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_marginAccount",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "_vusd",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "_wavax",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
     },
     {
-      "inputs": [],
-      "name": "addMarginWithAvax",
-      "outputs": [],
-      "stateMutability": "payable",
-      "type": "function"
+        "inputs": [],
+        "name": "addMarginWithAvax",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
     },
     {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "addVUSDMarginWithReserve",
-      "outputs": [],
-      "stateMutability": "payable",
-      "type": "function"
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "addVUSDMarginWithReserve",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
     },
     {
-      "inputs": [],
-      "name": "wavax",
-      "outputs": [
-        {
-          "internalType": "contract IWAVAX",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
+        "inputs": [],
+        "name": "wavax",
+        "outputs": [
+            {
+                "internalType": "contract IWAVAX",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
     }
-  ]
+]

--- a/tests/orderbook/abi/Oracle.json
+++ b/tests/orderbook/abi/Oracle.json
@@ -1,0 +1,158 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "chainLinkAggregatorMap",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "underlying",
+                "type": "address"
+            }
+        ],
+        "name": "getUnderlyingPrice",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "answer",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "underlying",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "intervalInSeconds",
+                "type": "uint256"
+            }
+        ],
+        "name": "getUnderlyingTwapPrice",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "governance",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_governance",
+                "type": "address"
+            }
+        ],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "underlying",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "aggregator",
+                "type": "address"
+            }
+        ],
+        "name": "setAggregator",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_governance",
+                "type": "address"
+            }
+        ],
+        "name": "setGovernace",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "underlying",
+                "type": "address"
+            },
+            {
+                "internalType": "int256",
+                "name": "price",
+                "type": "int256"
+            }
+        ],
+        "name": "setStablePrice",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "stablePrice",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+]

--- a/tests/orderbook/abi/OrderBook.json
+++ b/tests/orderbook/abi/OrderBook.json
@@ -5,6 +5,11 @@
                 "internalType": "address",
                 "name": "_clearingHouse",
                 "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "_marginAccount",
+                "type": "address"
             }
         ],
         "stateMutability": "nonpayable",
@@ -84,6 +89,12 @@
             {
                 "indexed": false,
                 "internalType": "uint256",
+                "name": "price",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
                 "name": "openInterestNotional",
                 "type": "uint256"
             },
@@ -92,6 +103,12 @@
                 "internalType": "address",
                 "name": "relayer",
                 "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "timestamp",
+                "type": "uint256"
             }
         ],
         "name": "LiquidationOrderMatched",
@@ -111,6 +128,12 @@
                 "internalType": "bytes32",
                 "name": "orderHash",
                 "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "timestamp",
+                "type": "uint256"
             }
         ],
         "name": "OrderCancelled",
@@ -176,6 +199,11 @@
                         "internalType": "uint256",
                         "name": "salt",
                         "type": "uint256"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "reduceOnly",
+                        "type": "bool"
                     }
                 ],
                 "indexed": false,
@@ -188,6 +216,12 @@
                 "internalType": "bytes",
                 "name": "signature",
                 "type": "bytes"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "timestamp",
+                "type": "uint256"
             }
         ],
         "name": "OrderPlaced",
@@ -231,6 +265,12 @@
                 "internalType": "address",
                 "name": "relayer",
                 "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "timestamp",
+                "type": "uint256"
             }
         ],
         "name": "OrdersMatched",
@@ -278,36 +318,9 @@
     {
         "inputs": [
             {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "ammIndex",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "address",
-                        "name": "trader",
-                        "type": "address"
-                    },
-                    {
-                        "internalType": "int256",
-                        "name": "baseAssetQuantity",
-                        "type": "int256"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "price",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "salt",
-                        "type": "uint256"
-                    }
-                ],
-                "internalType": "struct IOrderBook.Order[]",
-                "name": "orders",
-                "type": "tuple[]"
+                "internalType": "bytes32[]",
+                "name": "orderHashes",
+                "type": "bytes32[]"
             }
         ],
         "name": "cancelMultipleOrders",
@@ -318,36 +331,9 @@
     {
         "inputs": [
             {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "ammIndex",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "address",
-                        "name": "trader",
-                        "type": "address"
-                    },
-                    {
-                        "internalType": "int256",
-                        "name": "baseAssetQuantity",
-                        "type": "int256"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "price",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "salt",
-                        "type": "uint256"
-                    }
-                ],
-                "internalType": "struct IOrderBook.Order",
-                "name": "order",
-                "type": "tuple"
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
             }
         ],
         "name": "cancelOrder",
@@ -396,6 +382,11 @@
                         "internalType": "uint256",
                         "name": "salt",
                         "type": "uint256"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "reduceOnly",
+                        "type": "bool"
                     }
                 ],
                 "internalType": "struct IOrderBook.Order[2]",
@@ -459,6 +450,11 @@
                         "internalType": "uint256",
                         "name": "salt",
                         "type": "uint256"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "reduceOnly",
+                        "type": "bool"
                     }
                 ],
                 "internalType": "struct IOrderBook.Order",
@@ -517,6 +513,25 @@
         "inputs": [
             {
                 "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "isValidator",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
                 "name": "trader",
                 "type": "address"
             },
@@ -546,6 +561,11 @@
                         "internalType": "uint256",
                         "name": "salt",
                         "type": "uint256"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "reduceOnly",
+                        "type": "bool"
                     }
                 ],
                 "internalType": "struct IOrderBook.Order",
@@ -569,6 +589,19 @@
         "type": "function"
     },
     {
+        "inputs": [],
+        "name": "marginAccount",
+        "outputs": [
+            {
+                "internalType": "contract IMarginAccount",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
         "inputs": [
             {
                 "internalType": "bytes32",
@@ -579,6 +612,43 @@
         "name": "orderInfo",
         "outputs": [
             {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "ammIndex",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "trader",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "int256",
+                        "name": "baseAssetQuantity",
+                        "type": "int256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "price",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "salt",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "reduceOnly",
+                        "type": "bool"
+                    }
+                ],
+                "internalType": "struct IOrderBook.Order",
+                "name": "order",
+                "type": "tuple"
+            },
+            {
                 "internalType": "uint256",
                 "name": "blockPlaced",
                 "type": "uint256"
@@ -587,6 +657,11 @@
                 "internalType": "int256",
                 "name": "filledAmount",
                 "type": "int256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "reservedMargin",
+                "type": "uint256"
             },
             {
                 "internalType": "enum IOrderBook.OrderStatus",
@@ -669,6 +744,11 @@
                         "internalType": "uint256",
                         "name": "salt",
                         "type": "uint256"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "reduceOnly",
+                        "type": "bool"
                     }
                 ],
                 "internalType": "struct IOrderBook.Order",
@@ -759,6 +839,11 @@
                         "internalType": "uint256",
                         "name": "salt",
                         "type": "uint256"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "reduceOnly",
+                        "type": "bool"
                     }
                 ],
                 "internalType": "struct IOrderBook.Order",

--- a/tests/orderbook/package.json
+++ b/tests/orderbook/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "test.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha test.js --timeout 120000"
   },
   "author": "",
   "license": "ISC",

--- a/tests/orderbook/test.js
+++ b/tests/orderbook/test.js
@@ -12,6 +12,7 @@ const ClearingHouseContractAddress = "0x0300000000000000000000000000000000000071
 
 let provider, domain, orderType, orderBook, marginAccount, marginAccountHelper, clearingHouse
 let alice, bob, charlie, aliceAddress, bobAddress, charlieAddress
+let governance
 let alicePartialMatchedLongOrder, bobHighPriceShortOrder
 
 const ZERO = BigNumber.from(0)
@@ -19,6 +20,8 @@ const _1e6 = BigNumber.from(10).pow(6)
 const _1e8 = BigNumber.from(10).pow(8)
 const _1e12 = BigNumber.from(10).pow(12)
 const _1e18 = ethers.constants.WeiPerEther
+const maxLeverage = 5
+const tradeFeeRatio = 0.0025
 
 const homedir = require('os').homedir()
 let conf = require(`${homedir}/.hubblenet.json`)
@@ -29,6 +32,7 @@ describe('Submit transaction and compare with EVM state', function () {
         provider = new ethers.providers.JsonRpcProvider(url);
 
         // Set up signer
+        governance = new ethers.Wallet('0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80', provider) // governance
         alice = new ethers.Wallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d', provider); // 0x70997970c51812dc3a010c7d01b50e0d17dc79c8
         bob = new ethers.Wallet('0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a', provider); // 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc
         charlie = new ethers.Wallet('15614556be13730e9e8d6eacc1603143e7b96987429df8726384c2ec4502ef6e', provider); // 0x55ee05df718f1a5c1441e76190eb1a19ee2c9430
@@ -57,16 +61,35 @@ describe('Submit transaction and compare with EVM state', function () {
                 { name: "baseAssetQuantity", type: "int256" },
                 { name: "price", type: "uint256" },
                 { name: "salt", type: "uint256" },
+                { name: "reduceOnly", type: "bool" },
             ]
         }
 
     })
 
+    let aliceMargin = _1e6 * 150
+    let bobMargin = _1e6 * 150
+    let charlieMargin = 0
+
+    let aliceOrderSize = 0.1
+    let aliceOrderPrice = 1800
+    let aliceReserved = getReservedMargin(aliceOrderSize * aliceOrderPrice)
+    let aliceTradeFee = getTradeFee(aliceOrderSize * aliceOrderPrice)
+    let aliceOpenNotional = Math.abs(aliceOrderSize * aliceOrderPrice) * 1e6
+    let aliceLiquidationThreshold = getLiquidationThreshold(aliceOrderSize)
+
+
+    let bobOrderSize = -0.1
+    let bobOrderPrice = 1800
+    let bobOpenNotional = Math.abs(bobOrderSize * bobOrderPrice) * 1e6
+    let bobLiquidationThreshold = getLiquidationThreshold(bobOrderSize)
+    let bobTradeFee = getTradeFee(bobOrderSize * bobOrderPrice)
+
     it('Add margin', async function () {
-        tx = await addMargin(alice, _1e6.mul(40))
+        tx = await addMargin(alice, aliceMargin)
         await tx.wait();
 
-        tx = await addMargin(bob, _1e6.mul(40))
+        tx = await addMargin(bob, bobMargin)
         await tx.wait();
 
         const expectedState = {
@@ -74,14 +97,20 @@ describe('Submit transaction and compare with EVM state', function () {
             "trader_map": {
                 [bobAddress]: {
                     "positions": {},
-                    "margins": {
-                        "0": 40000000
+                    "margin": {
+                        "reserved": 0,
+                        "deposited": {
+                            "0": bobMargin
+                        }
                     }
                 },
                 [aliceAddress]: {
                     "positions": {},
-                    "margins": {
-                        "0": 40000000
+                    "margin": {
+                        "reserved": 0,
+                        "deposited": {
+                            "0": aliceMargin
+                        }
                     }
                 }
             },
@@ -91,11 +120,14 @@ describe('Submit transaction and compare with EVM state', function () {
             }
         }
         const evmState = await getEVMState()
+        // console.log(JSON.stringify(evmState, null, 2))
         expect(evmState).to.deep.contain(expectedState)
     });
 
     it('Remove margin', async function () {
-        const tx = await marginAccount.connect(alice).removeMargin(0, _1e6.mul(10))
+        const aliceMarginRemoved = _1e6 * 1
+        const tx = await marginAccount.connect(alice).removeMargin(0, aliceMarginRemoved)
+        aliceMargin = aliceMargin - aliceMarginRemoved
         await tx.wait();
 
         const expectedState = {
@@ -103,14 +135,20 @@ describe('Submit transaction and compare with EVM state', function () {
             "trader_map": {
                 [bobAddress]: {
                     "positions": {},
-                    "margins": {
-                        "0": 40000000
+                    "margin": {
+                        "reserved": 0,
+                        "deposited": {
+                            "0": bobMargin
+                        }
                     }
                 },
                 [aliceAddress]: {
                     "positions": {},
-                    "margins": {
-                        "0": 30000000
+                    "margin": {
+                        "reserved": 0,
+                        "deposited": {
+                            "0": aliceMargin
+                        }
                     }
                 }
             },
@@ -120,11 +158,12 @@ describe('Submit transaction and compare with EVM state', function () {
             }
         }
         const evmState = await getEVMState()
+        // console.log(JSON.stringify(evmState, null, 2))
         expect(evmState).to.deep.contain(expectedState)
     });
 
     it('Place order', async function () {
-        const { hash, order, signature, tx, txReceipt } = await placeOrder(alice, 5, 10, 101)
+        const { hash, order, signature, tx, txReceipt } = await placeOrder(alice, aliceOrderSize, aliceOrderPrice, 101)
 
         const expectedState = {
             "order_map": {
@@ -132,10 +171,10 @@ describe('Submit transaction and compare with EVM state', function () {
                     "market": 0,
                     "position_type": "long",
                     "user_address": aliceAddress,
-                    "base_asset_quantity": 5000000000000000000,
+                    "base_asset_quantity": _1e18 * aliceOrderSize,
                     "filled_base_asset_quantity": 0,
                     "salt": 101,
-                    "price": 10000000,
+                    "price": _1e6 * aliceOrderPrice,
                     "lifecycle_list": [
                         {
                             "BlockNumber": txReceipt.blockNumber,
@@ -143,20 +182,27 @@ describe('Submit transaction and compare with EVM state', function () {
                         }
                     ],
                     "signature": signature,
-                    "block_number": txReceipt.blockNumber
+                    "block_number": txReceipt.blockNumber,
+                    "reduce_only": false
                 }
             },
             "trader_map": {
                 [bobAddress]: {
                     "positions": {},
-                    "margins": {
-                        "0": 40000000
+                    "margin": {
+                        "reserved": 0,
+                        "deposited": {
+                            "0": bobMargin
+                        }
                     }
                 },
                 [aliceAddress]: {
                     "positions": {},
-                    "margins": {
-                        "0": 30000000
+                    "margin": {
+                        "reserved": aliceReserved,
+                        "deposited": {
+                            "0": aliceMargin
+                        }
                     }
                 }
             },
@@ -167,11 +213,332 @@ describe('Submit transaction and compare with EVM state', function () {
         }
 
         const evmState = await getEVMState()
+        // console.log(JSON.stringify(evmState, null, 2))
         expect(evmState).to.deep.contain(expectedState)
     });
 
     it('Match order', async function () {
-        await placeOrder(bob, -5, 10, 201)
+        const {tx} = await placeOrder(bob, bobOrderSize, bobOrderPrice, 201)
+        
+        await sleep(2)
+        
+        const expectedState = {
+            "order_map": {},
+            "trader_map": {
+                [bobAddress]: {
+                    "positions": {
+                        "0": {
+                            "open_notional": bobOpenNotional,
+                            "size": _1e18 * bobOrderSize,
+                            "unrealised_funding": 0,
+                            "last_premium_fraction": 0,
+                            "liquidation_threshold": bobLiquidationThreshold
+                        }
+                    },
+                    "margin": {
+                        "reserved": 0,
+                        "deposited": {
+                            "0": bobMargin - bobTradeFee
+                        }
+                    }
+                },
+                [aliceAddress]: {
+                    "positions": {
+                        "0": {
+                            "open_notional": aliceOpenNotional,
+                            "size": _1e18 * aliceOrderSize,
+                            "unrealised_funding": 0,
+                            "last_premium_fraction": 0,
+                            "liquidation_threshold": aliceLiquidationThreshold
+                        }
+                    },
+                    "margin": {
+                        "reserved": 0,
+                        "deposited": {
+                            "0": aliceMargin - aliceTradeFee
+                        }
+                    }
+                }
+            },
+            "next_funding_time": await getNextFundingTime(),
+            "last_price": {
+                "0": _1e6 * aliceOrderPrice
+            }
+        }
+        const evmState = await getEVMState()
+        // console.log(JSON.stringify(evmState, null, 2))
+        expect(evmState).to.deep.contain(expectedState)
+    });
+
+    it('Order cancel', async function () {
+        const { hash, order } = await placeOrder(alice, 0.1, 1800, 401)
+
+        tx = await orderBook.connect(alice).cancelOrder(hash)
+        await tx.wait()
+
+        // same as last test scenario
+        const expectedState = {
+            "order_map": {},
+            "trader_map": {
+                [bobAddress]: {
+                    "positions": {
+                        "0": {
+                            "open_notional": bobOpenNotional,
+                            "size": _1e18 * bobOrderSize,
+                            "unrealised_funding": 0,
+                            "last_premium_fraction": 0,
+                            "liquidation_threshold": bobLiquidationThreshold
+                        }
+                    },
+                    "margin": {
+                        "reserved": 0,
+                        "deposited": {
+                            "0": bobMargin - bobTradeFee
+                        }
+                    }
+                },
+                [aliceAddress]: {
+                    "positions": {
+                        "0": {
+                            "open_notional": aliceOpenNotional,
+                            "size": _1e18 * aliceOrderSize,
+                            "unrealised_funding": 0,
+                            "last_premium_fraction": 0,
+                            "liquidation_threshold": aliceLiquidationThreshold
+                        }
+                    },
+                    "margin": {
+                        "reserved": 0,
+                        "deposited": {
+                            "0": aliceMargin - aliceTradeFee
+                        }
+                    }
+                }
+            },
+            "next_funding_time": await getNextFundingTime(),
+            "last_price": {
+                "0": _1e6 * aliceOrderPrice
+            }
+        }
+
+        const evmState = await getEVMState()
+        // console.log(JSON.stringify(evmState, null, 2))
+        expect(evmState).to.deep.contain(expectedState)
+    });
+
+    it('Partially match order', async function () {
+        alicePartialMatchedLongOrder = await placeOrder(alice, 0.2, aliceOrderPrice, 301)
+        const { tx, hash: bobShortOrderHash } = await placeOrder(bob, -0.1, bobOrderPrice, 302)
+
+        await tx.wait()
+
+        aliceOrderSize = aliceOrderSize + 0.1
+        bobOrderSize = bobOrderSize - 0.1
+        bobOpenNotional = Math.abs(bobOrderSize * bobOrderPrice) * 1e6
+        aliceOpenNotional = Math.abs(aliceOrderSize * aliceOrderPrice) * 1e6
+        bobLiquidationThreshold = getLiquidationThreshold(bobOrderSize)
+        aliceLiquidationThreshold = getLiquidationThreshold(aliceOrderSize)
+
+        aliceTradeFee = getTradeFee(0.2 * aliceOrderPrice)
+        bobTradeFee = getTradeFee(0.2 * bobOrderPrice)
+        aliceReserved = getReservedMargin(0.1 * aliceOrderPrice) // reserved only for 0.1 size
+        const expectedState = {
+            "order_map": {
+                [alicePartialMatchedLongOrder.hash]: {
+                    "market": 0,
+                    "position_type": "long",
+                    "user_address": aliceAddress,
+                    "base_asset_quantity": 200000000000000000,
+                    "filled_base_asset_quantity": 100000000000000000,
+                    "salt": 301,
+                    "price": 1800000000,
+                    "lifecycle_list": [
+                        {
+                            "BlockNumber": alicePartialMatchedLongOrder.txReceipt.blockNumber,
+                            "Status": 0
+                        }
+                    ],
+                    "signature": alicePartialMatchedLongOrder.signature,
+                    "block_number": alicePartialMatchedLongOrder.txReceipt.blockNumber,
+                    "reduce_only": false
+                }
+            },
+            "trader_map": {
+                [bobAddress]: {
+                    "positions": {
+                        "0": {
+                            "open_notional": bobOpenNotional,
+                            "size": _1e18 * bobOrderSize,
+                            "unrealised_funding": 0,
+                            "last_premium_fraction": 0,
+                            "liquidation_threshold": bobLiquidationThreshold
+                        }
+                    },
+                    "margin": {
+                        "reserved": 0,
+                        "deposited": {
+                            "0": bobMargin - bobTradeFee
+                        }
+                    }
+                },
+                [aliceAddress]: {
+                    "positions": {
+                        "0": {
+                            "open_notional": aliceOpenNotional,
+                            "size": _1e18 * aliceOrderSize,
+                            "unrealised_funding": 0,
+                            "last_premium_fraction": 0,
+                            "liquidation_threshold": aliceLiquidationThreshold
+                        }
+                    },
+                    "margin": {
+                        "reserved": aliceReserved,
+                        "deposited": {
+                            "0": aliceMargin - aliceTradeFee
+                        }
+                    }
+                }
+            },
+            "next_funding_time": await getNextFundingTime(),
+            "last_price": {
+                "0": _1e6 * aliceOrderPrice
+            }
+        }
+        const evmState = await getEVMState()
+        // console.log(JSON.stringify(evmState, null, 2))
+        expect(evmState).to.deep.contain(expectedState)
+    });
+
+
+    // it.skip('Order match error', async function () {
+    //     // place an order with reduceOnly which should fail
+    //     // const { hash: charlieHash } = await placeOrder(charlie, 50, 12, 501)
+    //     await orderBook.connect(alice).cancelOrder(alicePartialMatchedLongOrder.hash)
+    //     bobReverseOrder = await placeOrder(bob, 6.95, 10, 501)
+    //     aliceReverseOrder = await placeOrder(alice, -7, 10, 502)
+    //     // bobHighPriceShortOrder = await placeOrder(bob, -2, 10, 502) // reduceOnly; this should fail while matching
+
+    //     await sleep(2)
+    //     const expectedState = {
+    //         "order_map": {
+    //             [aliceReverseOrder.hash]: {
+    //                 "market": 0,
+    //                 "position_type": "short",
+    //                 "user_address": aliceAddress,
+    //                 "base_asset_quantity": -7000000000000000000,
+    //                 "filled_base_asset_quantity": -6950000000000000000,
+    //                 "salt": 502,
+    //                 "price": 10000000,
+    //                 "lifecycle_list": [
+    //                     {
+    //                         "BlockNumber": aliceReverseOrder.txReceipt.blockNumber,
+    //                         "Status": 0
+    //                     }
+    //                 ],
+    //                 "signature": aliceReverseOrder.signature,
+    //                 "block_number": aliceReverseOrder.txReceipt.blockNumber,
+    //                 "reduce_only": false
+    //             }
+    //         },
+    //         "trader_map": {
+    //             [bobAddress]: {
+    //                 "positions": {
+    //                     "0": {
+    //                         "open_notional": 70000000,
+    //                         "size": -7000000000000000000,
+    //                         "unrealised_funding": 0,
+    //                         "last_premium_fraction": 0,
+    //                         "liquidation_threshold": -5000000000000000000
+    //                     }
+    //                 },
+    //                 "margin": {
+    //                     "reserved": 0,
+    //                     "deposited": {
+    //                         "0": 39965000
+    //                     }
+    //                 }
+    //             },
+    //             [aliceAddress]: {
+    //                 "positions": {
+    //                     "0": {
+    //                         "open_notional": 70000000,
+    //                         "size": 7000000000000000000,
+    //                         "unrealised_funding": 0,
+    //                         "last_premium_fraction": 0,
+    //                         "liquidation_threshold": 5000000000000000000
+    //                     }
+    //                 },
+    //                 "margin": {
+    //                     "reserved": 0,
+    //                     "deposited": {
+    //                         "0": 29965000
+    //                     }
+    //                 }
+    //             }
+    //         },
+    //         "next_funding_time": await getNextFundingTime(),
+    //         "last_price": {
+    //             "0": 10000000
+    //         }
+    //     }
+    //     const evmState = await getEVMState()
+    //     console.log(JSON.stringify(evmState, null, 2))
+    //     expect(evmState).to.deep.contain(expectedState)
+    // });
+
+    it('Liquidate trader', async function () {
+        await addMargin(charlie, _1e6.mul(100))
+        await addMargin(alice, _1e6.mul(300))
+        await addMargin(bob, _1e6.mul(200))
+
+        await orderBook.connect(alice).cancelOrder(alicePartialMatchedLongOrder.hash)
+        
+        aliceMargin = aliceMargin + (_1e6 * 300)
+        bobMargin = bobMargin + (_1e6 * 200)
+        charlieMargin = _1e6 * 100
+
+        // large position by charlie
+        let charlieOrderSize = 0.25
+        let charliePrice = 1800
+        await placeOrder(charlie, charlieOrderSize, charliePrice, 601)
+        await placeOrder(bob, -charlieOrderSize, charliePrice, 602)
+
+        bobOrderSize -= charlieOrderSize
+        bobOpenNotional = bobOpenNotional + Math.abs(charlieOrderSize * charliePrice * _1e6)
+        let charlieOpenNotional = Math.abs(charlieOrderSize * charliePrice * _1e6)
+
+        // reduce the price
+        let reducedPrice = 1400
+        await setOraclePrice(0, reducedPrice * _1e6)
+        const { hash: aliceHash } = await placeOrder(alice, 0.01, reducedPrice, 603)
+        const { hash: bobHash2 } = await placeOrder(bob, -0.01, reducedPrice, 604)
+
+        bobOpenNotional = bobOpenNotional + Math.abs(0.01 * reducedPrice * _1e6)
+        aliceOpenNotional = aliceOpenNotional + Math.abs(0.01 * reducedPrice * _1e6)
+        aliceOrderSize += 0.01
+        bobOrderSize -= 0.01
+        bobLiquidationThreshold = getLiquidationThreshold(bobOrderSize)
+        aliceLiquidationThreshold = getLiquidationThreshold(aliceOrderSize)
+        let charlieLiquidationThreshold = getLiquidationThreshold(charlieOrderSize)
+        aliceTradeFee =  getTradeFee(aliceOpenNotional/_1e6)
+        bobTradeFee = getTradeFee(bobOpenNotional/_1e6)
+        let charlieTradeFee = getTradeFee(charlieOpenNotional/_1e6)
+
+        // 1 long order so that liquidation can run
+        // const aliceNewPrice = 1800
+        // let increasedPrice = 1800
+        // await setOraclePrice(0, increasedPrice * _1e6)
+        const aliceLongOrderForLiquidation = await placeOrder(alice, charlieOrderSize, reducedPrice, 605)
+        aliceOrderSize += charlieOrderSize
+        aliceOpenNotional = aliceOpenNotional + Math.abs(charlieOrderSize * reducedPrice * _1e6)
+        aliceLiquidationThreshold = getLiquidationThreshold(aliceOrderSize)
+        aliceTradeFee = aliceTradeFee + getTradeFee(charlieOrderSize * reducedPrice)
+
+        charlieMargin = (_1e6 * 100
+            - charlieTradeFee // tradeFee for initial order
+            - (reducedPrice * charlieOrderSize * 0.05 * _1e6) // 5% liquidation penalty
+            - ((charliePrice - reducedPrice) *  charlieOrderSize * _1e6)) // negative pnl for liquidated position
+
 
         const expectedState = {
             "order_map": {},
@@ -179,350 +546,77 @@ describe('Submit transaction and compare with EVM state', function () {
                 [bobAddress]: {
                     "positions": {
                         "0": {
-                            "open_notional": 50000000,
-                            "size": -5000000000000000000,
-                            "unrealised_funding": null,
+                            "open_notional": bobOpenNotional,
+                            "size": _1e18 * bobOrderSize,
+                            "unrealised_funding": 0,
                             "last_premium_fraction": 0,
-                            "liquidation_threshold": -5000000000000000000
+                            "liquidation_threshold": bobLiquidationThreshold
                         }
                     },
-                    "margins": {
-                        "0": 39975000
+                    "margin": {
+                        "reserved": 0,
+                        "deposited": {
+                            "0": bobMargin - bobTradeFee
+                        }
                     }
                 },
                 [aliceAddress]: {
                     "positions": {
                         "0": {
-                            "open_notional": 50000000,
-                            "size": 5000000000000000000,
-                            "unrealised_funding": null,
+                            "open_notional": aliceOpenNotional,
+                            "size": _1e18 * aliceOrderSize,
+                            "unrealised_funding": 0,
                             "last_premium_fraction": 0,
-                            "liquidation_threshold": 5000000000000000000
+                            "liquidation_threshold": aliceLiquidationThreshold
                         }
                     },
-                    "margins": {
-                        "0": 29975000
-                    }
-                }
-            },
-            "next_funding_time": await getNextFundingTime(),
-            "last_price": {
-                "0": 10000000
-            }
-        }
-        const evmState = await getEVMState()
-        expect(evmState).to.deep.contain(expectedState)
-    });
-
-    it('Partially match order', async function () {
-        alicePartialMatchedLongOrder = await placeOrder(alice, 5, 10, 301)
-        const { hash: bobShortOrderHash } = await placeOrder(bob, -2, 10, 302)
-
-        const expectedState = {
-            "order_map": {
-                [alicePartialMatchedLongOrder.hash]: {
-                    "market": 0,
-                    "position_type": "long",
-                    "user_address": aliceAddress,
-                    "base_asset_quantity": 5000000000000000000,
-                    "filled_base_asset_quantity": 2000000000000000000,
-                    "salt": 301,
-                    "price": 10000000,
-                    "lifecycle_list": [
-                        {
-                            "BlockNumber": alicePartialMatchedLongOrder.txReceipt.blockNumber,
-                            "Status": 0
+                    "margin": {
+                        "reserved": 0,
+                        "deposited": {
+                            "0": aliceMargin - aliceTradeFee
                         }
-                    ],
-                    "signature": alicePartialMatchedLongOrder.signature,
-                    "block_number": alicePartialMatchedLongOrder.txReceipt.blockNumber
-                }
-            },
-            "trader_map": {
-                [bobAddress]: {
-                    "positions": {
-                        "0": {
-                            "open_notional": 70000000,
-                            "size": -7000000000000000000,
-                            "unrealised_funding": null,
-                            "last_premium_fraction": 0,
-                            "liquidation_threshold": -5000000000000000000
-                        }
-                    },
-                    "margins": {
-                        "0": 39965000
-                    }
-                },
-                [aliceAddress]: {
-                    "positions": {
-                        "0": {
-                            "open_notional": 70000000,
-                            "size": 7000000000000000000,
-                            "unrealised_funding": null,
-                            "last_premium_fraction": 0,
-                            "liquidation_threshold": 5000000000000000000
-                        }
-                    },
-                    "margins": {
-                        "0": 29965000
-                    }
-                }
-            },
-            "next_funding_time": await getNextFundingTime(),
-            "last_price": {
-                "0": 10000000
-            }
-        }
-        const evmState = await getEVMState()
-        expect(evmState).to.deep.contain(expectedState)
-    });
-
-    it('Order cancel', async function () {
-        const { hash, order } = await placeOrder(alice, 2, 14, 401)
-
-        tx = await orderBook.connect(alice).cancelOrder(order)
-        await tx.wait()
-
-        const expectedState = {
-            "order_map": {
-                [alicePartialMatchedLongOrder.hash]: {
-                    "market": 0,
-                    "position_type": "long",
-                    "user_address": aliceAddress,
-                    "base_asset_quantity": 5000000000000000000,
-                    "filled_base_asset_quantity": 2000000000000000000,
-                    "salt": 301,
-                    "price": 10000000,
-                    "lifecycle_list": [
-                        {
-                            "BlockNumber": alicePartialMatchedLongOrder.txReceipt.blockNumber,
-                            "Status": 0
-                        }
-                    ],
-                    "signature": alicePartialMatchedLongOrder.signature,
-                    "block_number": alicePartialMatchedLongOrder.txReceipt.blockNumber
-                }
-            },
-            "trader_map": {
-                [bobAddress]: {
-                    "positions": {
-                        "0": {
-                            "open_notional": 70000000,
-                            "size": -7000000000000000000,
-                            "unrealised_funding": null,
-                            "last_premium_fraction": 0,
-                            "liquidation_threshold": -5000000000000000000
-                        }
-                    },
-                    "margins": {
-                        "0": 39965000
-                    }
-                },
-                [aliceAddress]: {
-                    "positions": {
-                        "0": {
-                            "open_notional": 70000000,
-                            "size": 7000000000000000000,
-                            "unrealised_funding": null,
-                            "last_premium_fraction": 0,
-                            "liquidation_threshold": 5000000000000000000
-                        }
-                    },
-                    "margins": {
-                        "0": 29965000
-                    }
-                }
-            },
-            "next_funding_time": await getNextFundingTime(),
-            "last_price": {
-                "0": 10000000
-            }
-        }
-
-        const evmState = await getEVMState()
-        expect(evmState).to.deep.contain(expectedState)
-    });
-
-    it('Order match error', async function () {
-        const { hash: charlieHash } = await placeOrder(charlie, 50, 12, 501)
-        bobHighPriceShortOrder = await placeOrder(bob, -10, 12, 502)
-
-        const expectedState = {
-            "order_map": {
-                [alicePartialMatchedLongOrder.hash]: {
-                    "market": 0,
-                    "position_type": "long",
-                    "user_address": aliceAddress,
-                    "base_asset_quantity": 5000000000000000000,
-                    "filled_base_asset_quantity": 2000000000000000000,
-                    "salt": 301,
-                    "price": 10000000,
-                    "lifecycle_list": [
-                        {
-                            "BlockNumber": alicePartialMatchedLongOrder.txReceipt.blockNumber,
-                            "Status": 0
-                        }
-                    ],
-                    "signature": alicePartialMatchedLongOrder.signature,
-                    "block_number": alicePartialMatchedLongOrder.txReceipt.blockNumber
-                },
-                [bobHighPriceShortOrder.hash]: {
-                    "market": 0,
-                    "position_type": "short",
-                    "user_address": bobAddress,
-                    "base_asset_quantity": -10000000000000000000,
-                    "filled_base_asset_quantity": 0,
-                    "salt": 502,
-                    "price": 12000000,
-                    "lifecycle_list": [
-                        {
-                            "BlockNumber": bobHighPriceShortOrder.txReceipt.blockNumber,
-                            "Status": 0
-                        }
-                    ],
-                    "signature": bobHighPriceShortOrder.signature,
-                    "block_number": bobHighPriceShortOrder.txReceipt.blockNumber
-                }
-            },
-            "trader_map": {
-                [bobAddress]: {
-                    "positions": {
-                        "0": {
-                            "open_notional": 70000000,
-                            "size": -7000000000000000000,
-                            "unrealised_funding": null,
-                            "last_premium_fraction": 0,
-                            "liquidation_threshold": -5000000000000000000
-                        }
-                    },
-                    "margins": {
-                        "0": 39965000
-                    }
-                },
-                [aliceAddress]: {
-                    "positions": {
-                        "0": {
-                            "open_notional": 70000000,
-                            "size": 7000000000000000000,
-                            "unrealised_funding": null,
-                            "last_premium_fraction": 0,
-                            "liquidation_threshold": 5000000000000000000
-                        }
-                    },
-                    "margins": {
-                        "0": 29965000
-                    }
-                }
-            },
-            "next_funding_time": await getNextFundingTime(),
-            "last_price": {
-                "0": 10000000
-            }
-        }
-        const evmState = await getEVMState()
-        expect(evmState).to.deep.contain(expectedState)
-    });
-
-    it('Liquidate trader', async function () {
-        await addMargin(charlie, _1e6.mul(100))
-        await addMargin(alice, _1e6.mul(200))
-        await addMargin(bob, _1e6.mul(200))
-
-        await sleep(3)
-
-        // large position by charlie
-        const { hash: charlieHash } = await placeOrder(charlie, 49, 10, 601) // 46 + 3 is fulfilled
-        const { hash: bobHash1 } = await placeOrder(bob, -49, 10, 602) // 46 + 3
-
-        // reduce the price
-        const { hash: aliceHash } = await placeOrder(alice, 10, 8, 603) // 7 matched; 3 used for liquidation
-        const { hash: bobHash2 } = await placeOrder(bob, -10, 8, 604) // 3 + 7
-
-        // long order so that liquidation can run
-        const { hash } = await placeOrder(alice, 10, 8, 605) // 10 used for liquidation
-
-        const expectedState = {
-            "order_map": {
-                [bobHighPriceShortOrder.hash]: {
-                    "market": 0,
-                    "position_type": "short",
-                    "user_address": bobAddress,
-                    "base_asset_quantity": -10000000000000000000,
-                    "filled_base_asset_quantity": 0,
-                    "salt": 502,
-                    "price": 12000000,
-                    "lifecycle_list": [
-                        {
-                            "BlockNumber": bobHighPriceShortOrder.txReceipt.blockNumber,
-                            "Status": 0
-                        }
-                    ],
-                    "signature": bobHighPriceShortOrder.signature,
-                    "block_number": bobHighPriceShortOrder.txReceipt.blockNumber
-                }
-            },
-            "trader_map": {
-                [bobAddress]: {
-                    "positions": {
-                        "0": {
-                            "open_notional": 646000000,
-                            "size": -66000000000000000000,
-                            "unrealised_funding": null,
-                            "last_premium_fraction": 0,
-                            "liquidation_threshold": -16500000000000000000
-                        }
-                    },
-                    "margins": {
-                        "0": 239677000
                     }
                 },
                 [charlieAddress]: {
                     "positions": {
                         "0": {
-                            "open_notional": 360000000,
-                            "size": 36000000000000000000,
-                            "unrealised_funding": null,
+                            "open_notional": 0,
+                            "size": 0,
+                            "unrealised_funding": 0,
                             "last_premium_fraction": 0,
-                            "liquidation_threshold": 12250000000000000000
+                            "liquidation_threshold": 0
                         }
                     },
-                    "margins": {
-                        "0": 68555000
-                    }
-                },
-                [aliceAddress]: {
-                    "positions": {
-                        "0": {
-                            "open_notional": 260000000,
-                            "size": 30000000000000000000,
-                            "unrealised_funding": null,
-                            "last_premium_fraction": 0,
-                            "liquidation_threshold": 7500000000000000000
+                    "margin": {
+                        "reserved": 0,
+                        "deposited": {
+                            "0": charlieMargin
                         }
-                    },
-                    "margins": {
-                        "0": 229870000
                     }
                 }
             },
             "next_funding_time": await getNextFundingTime(),
             "last_price": {
-                "0": 8000000
+                "0": _1e6 * reducedPrice
             }
         }
 
+        await sleep(5)
         const evmState = await getEVMState()
+        // console.log(JSON.stringify(evmState, null, 2))
+        // console.log(JSON.stringify(expectedState, null, 2))
         expect(evmState).to.deep.contain(expectedState)
     });
 });
 
-async function placeOrder(trader, size, price, salt) {
+async function placeOrder(trader, size, price, salt, reduceOnly=false) {
     const order = {
         ammIndex: ZERO,
         trader: trader.address,
         baseAssetQuantity: ethers.utils.parseEther(size.toString()),
         price: ethers.utils.parseUnits(price.toString(), 6),
-        salt: BigNumber.from(salt)
+        salt: BigNumber.from(salt),
+        reduceOnly: reduceOnly,
     }
     const signature = await trader._signTypedData(domain, orderType, order)
     const hash = await orderBook.connect(trader).getOrderHash(order)
@@ -541,6 +635,35 @@ async function getNextFundingTime() {
     const fundingEvents = await clearingHouse.queryFilter('FundingRateUpdated')
     const latestFundingEvent = fundingEvents.pop()
     return latestFundingEvent.args.nextFundingTime.toNumber()
+}
+
+function getLiquidationThreshold(size) {
+    const absSize = Math.abs(size)
+    let liquidationThreshold = Math.max(absSize / 4, 0.01)
+    return size >= 0 ? _1e18 * liquidationThreshold : _1e18 * -liquidationThreshold;
+}
+
+function getReservedMargin(notional) {
+    const leveraged = Math.abs(notional / maxLeverage)
+    let tradeFee = leveraged * tradeFeeRatio
+    let reserved = leveraged + tradeFee
+    return _1e6 * reserved
+}
+
+function getTradeFee(notional) {
+    const leveraged = Math.abs(notional / maxLeverage)
+    let tradeFee = leveraged * tradeFeeRatio
+    return _1e6 * tradeFee
+}
+
+async function setOraclePrice(market, price) {
+    const ammAddress = await clearingHouse.amms(market)
+    const amm = new ethers.Contract(ammAddress, require('./abi/AMM.json'), provider);
+    const underlying = await amm.underlyingAsset()
+    const oracleAddress = await marginAccount.oracle()
+    const oracle = new ethers.Contract(oracleAddress, require('./abi/Oracle.json'), provider);
+
+    await oracle.connect(governance).setStablePrice(underlying, price)
 }
 
 async function getEVMState() {


### PR DESCRIPTION
## Why this should be merged
- Fixes integration tests
- All memory db functions now return a deepcopy of `LimitOrder` struct. This is required because changing a BigInt value changes it in the memory database as well. For example in [liquidate](https://github.com/hubble-exchange/subnet-evm/blob/hubble-v2/plugin/evm/limitorders/build_block_pipeline.go#L136) function
- Updates minSizeRequirement

## How this was tested
On local network by using `npm test`

