### PR TITLE
Save snapshots of memory database to improve node restart time

### DIFF
--- a/consensus/dummy/consensus.go
+++ b/consensus/dummy/consensus.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ava-labs/subnet-evm/trie"
 	"github.com/ava-labs/subnet-evm/vmerrs"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
+	// "github.com/ethereum/go-ethereum/log"
 )
 
 var (
@@ -323,7 +323,7 @@ func (self *DummyEngine) verifyBlockFee(
 	//
 	// NOTE: To determine the [requiredBlockFee], multiply [requiredBlockGasCost]
 	// by [baseFee].
-	log.Info("verifyBlockFee", "blockGas", blockGas, "requiredBlockGasCost", requiredBlockGasCost, "baseFee", baseFee, "totalBlockFee", totalBlockFee)
+	// log.Info("verifyBlockFee", "blockGas", blockGas, "requiredBlockGasCost", requiredBlockGasCost, "baseFee", baseFee, "totalBlockFee", totalBlockFee)
 	if blockGas.Cmp(requiredBlockGasCost) < 0 {
 		return fmt.Errorf(
 			"insufficient gas (%d) to cover the block cost (%d) at base fee (%d) (total block fee: %d)",

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -74,38 +74,46 @@ func (lop *limitOrderProcesser) ListenAndProcessTransactions() {
 	if lastAccepted.Sign() > 0 {
 		fromBlock := big.NewInt(0)
 
-		// first load the last snapshot containing data till block x, then parse all the logs since block x + 1
-		blockNumber, err := lop.loadMemoryDBSnapshot()
+		// first load the last snapshot containing finalised data till block x and unfinalised data will block y
+		acceptedBlockNumber, headBlockNumber, err := lop.loadMemoryDBSnapshot()
 		if err != nil {
-			log.Error("ListenAndProcessTransactions - Error in loading snapshot", "err", err)
-		}
-		if blockNumber > 0 {
-			log.Info("ListenAndProcessTransactions - Memory DB snapshot loaded", "blockNumber", blockNumber)
-			fromBlock = big.NewInt(int64(blockNumber + 1))
-		}
-
-		log.Info("ListenAndProcessTransactions - beginning sync", " till block number", lastAccepted)
-		ctx := context.Background()
-
-		var toBlock *big.Int
-		toBlock = utils.BigIntMin(lastAccepted, big.NewInt(0).Add(fromBlock, big.NewInt(10000)))
-		for toBlock.Cmp(fromBlock) > 0 {
-			logs, err := lop.filterAPI.GetLogs(ctx, filters.FilterCriteria{
-				FromBlock: fromBlock,
-				ToBlock:   toBlock, // check that this is inclusive...
-				Addresses: []common.Address{limitorders.OrderBookContractAddress, limitorders.ClearingHouseContractAddress, limitorders.MarginAccountContractAddress},
-			})
-			log.Info("ListenAndProcessTransactions", "fromBlock", fromBlock.String(), "toBlock", toBlock.String(), "number of logs", len(logs), "err", err)
-			if err != nil {
-				log.Error("ListenAndProcessTransactions - GetLogs failed", "err", err)
-				panic(err)
+			log.Error("ListenAndProcessTransactions - error in loading snapshot", "err", err)
+		} else {
+			if acceptedBlockNumber > 0 && headBlockNumber > 0 {
+				log.Info("ListenAndProcessTransactions - memory DB snapshot loaded", "acceptedBlockNumber", acceptedBlockNumber, "headBlockNumber", headBlockNumber)
+			} else {
+				// not an error, but unlikely after the blockchain is running for some time
+				log.Warn("ListenAndProcessTransactions - no snapshot found")
 			}
-			lop.contractEventProcessor.ProcessEvents(logs)
+		}
+
+		if acceptedBlockNumber == 0 && headBlockNumber == 0 {
+			// snapshot was not loaded, start from the beginnning and fetch the logs in chunks
+			log.Info("ListenAndProcessTransactions - beginning sync", " till block number", lastAccepted)
+			toBlock := utils.BigIntMin(lastAccepted, big.NewInt(0).Add(fromBlock, big.NewInt(10000)))
+			for toBlock.Cmp(fromBlock) > 0 {
+				logs := lop.getLogs(fromBlock, toBlock)
+				log.Info("ListenAndProcessTransactions - fetching log chunk", "fromBlock", fromBlock.String(), "toBlock", toBlock.String(), "number of logs", len(logs), "err", err)
+				lop.contractEventProcessor.ProcessEvents(logs)
+				lop.contractEventProcessor.ProcessAcceptedEvents(logs)
+
+				fromBlock = fromBlock.Add(toBlock, big.NewInt(1))
+				toBlock = utils.BigIntMin(lastAccepted, big.NewInt(0).Add(fromBlock, big.NewInt(10000)))
+			}
+		} else {
+			// snapshot was loaded; fetch only the logs after snapshot blocks(separately for both accepted and head block)
+			// no need to break it into chunks cuz the remaining blocks should be few
+			fromBlock = big.NewInt(int64(acceptedBlockNumber) + 1)
+			logs := lop.getLogs(fromBlock, lastAccepted)
+			log.Info("ListenAndProcessTransactions - fetched logs since accepted block", "fromBlock", fromBlock.String(), "toBlock", lastAccepted.String(), "number of logs", len(logs), "err", err)
 			lop.contractEventProcessor.ProcessAcceptedEvents(logs)
 
-			fromBlock = fromBlock.Add(toBlock, big.NewInt(1))
-			toBlock = utils.BigIntMin(lastAccepted, big.NewInt(0).Add(fromBlock, big.NewInt(10000)))
+			fromBlock = big.NewInt(int64(headBlockNumber) + 1)
+			logs = lop.getLogs(fromBlock, lastAccepted)
+			log.Info("ListenAndProcessTransactions - fetched logs since head block", "fromBlock", fromBlock.String(), "toBlock", lastAccepted.String(), "number of logs", len(logs), "err", err)
+			lop.contractEventProcessor.ProcessEvents(logs)
 		}
+
 		lop.memoryDb.Accept(lastAccepted.Uint64()) // will delete stale orders from the memorydb
 	}
 
@@ -182,67 +190,84 @@ func (lop *limitOrderProcesser) handleChainAcceptedEvent(event core.ChainEvent) 
 		err := lop.saveMemoryDBSnapshot(block.Number())
 		if err != nil {
 			log.Error("Error in saving memory DB snapshot", "err", err)
-		} else {
-			log.Info("Saved memory DB snapshot successfully")
 		}
 
 	}
 }
 
-func (lop *limitOrderProcesser) loadMemoryDBSnapshot() (blockNumber uint64, err error) {
+func (lop *limitOrderProcesser) loadMemoryDBSnapshot() (acceptedBlockNumber uint64, headBlockNumber uint64, err error) {
 	snapshotFound, err := lop.hubbleDB.Has([]byte(memoryDBSnapshotKey))
 	if err != nil {
-		return blockNumber, fmt.Errorf("Error in checking snapshot: err=%v", err)
+		return acceptedBlockNumber, headBlockNumber, fmt.Errorf("Error in checking snapshot in hubbleDB: err=%v", err)
 	}
 
 	if !snapshotFound {
-		return blockNumber, nil
+		return acceptedBlockNumber, headBlockNumber, nil
 	}
 
 	memorySnapshotBytes, err := lop.hubbleDB.Get([]byte(memoryDBSnapshotKey))
 	if err != nil {
-		return blockNumber, fmt.Errorf("Error in fetching snapshot: err=%v", err)
+		return acceptedBlockNumber, headBlockNumber, fmt.Errorf("Error in fetching snapshot from hubbleDB; err=%v", err)
 	}
 
 	buf := bytes.NewBuffer(memorySnapshotBytes)
 	var snapshot limitorders.Snapshot
 	err = gob.NewDecoder(buf).Decode(&snapshot)
 	if err != nil {
-		log.Error("Error in gob parsing", "snapshotbytes", string(memorySnapshotBytes))
-		return blockNumber, fmt.Errorf("Error in json parsing: err=%v", err)
+		return acceptedBlockNumber, headBlockNumber, fmt.Errorf("Error in snapshot parsing; err=%v", err)
+	}
+
+	if snapshot.HeadBlockNumber.Uint64() == 0 || snapshot.AcceptedBlockNumber.Uint64() == 0 {
+		return acceptedBlockNumber, headBlockNumber, fmt.Errorf("Invalid snapshot; accepted block number =%d, head block number =%v",
+			snapshot.AcceptedBlockNumber.Uint64(), snapshot.HeadBlockNumber.Uint64())
+	}
+
+	headBlock := lop.blockChain.GetBlockByNumber(snapshot.HeadBlockNumber.Uint64())
+	if headBlock.Hash() != snapshot.HeadBlockHash {
+		// if the head block at the time of saving the snapshot is not part of the finalised blockchain now,
+		// it means there was a reorg and the snapshot has to be discarded
+		// This should happen very rarely
+		return acceptedBlockNumber, headBlockNumber, fmt.Errorf("HeadBlock mismatch; block number =%d, snapshot head block=%v, blockchain head block=%v",
+			snapshot.HeadBlockNumber.Uint64(), snapshot.HeadBlockHash.String(), headBlock.Hash().String())
 	}
 
 	err = lop.memoryDb.LoadFromSnapshot(snapshot)
 	if err != nil {
-		return blockNumber, fmt.Errorf("Error in loading from snapshot: err=%v", err)
+		return acceptedBlockNumber, headBlockNumber, fmt.Errorf("Error in loading from snapshot: err=%v", err)
 	}
 
-	return snapshot.BlockNumber.Uint64(), nil
+	return snapshot.AcceptedBlockNumber.Uint64(), snapshot.HeadBlockNumber.Uint64(), nil
 }
 
-func (lop *limitOrderProcesser) saveMemoryDBSnapshot(blockNumber *big.Int) error {
-	memoryDb := lop.memoryDb.GetOrderBookData()
+func (lop *limitOrderProcesser) saveMemoryDBSnapshot(acceptedBlockNumber *big.Int) error {
+	currentHeadBlock := lop.blockChain.CurrentBlock()
 
-	snapshot := limitorders.Snapshot{
-		Data: limitorders.InMemoryDatabase{
-			OrderMap:        memoryDb.OrderMap,
-			TraderMap:       memoryDb.TraderMap,
-			LastPrice:       memoryDb.LastPrice,
-			NextFundingTime: memoryDb.NextFundingTime,
-		},
-		BlockNumber: blockNumber,
-	}
-
-	var buf bytes.Buffer
-	err := gob.NewEncoder(&buf).Encode(&snapshot)
+	snapshotBytes, err := lop.memoryDb.GenerateSnapshot(acceptedBlockNumber, currentHeadBlock.Number(), currentHeadBlock.Hash())
 	if err != nil {
-		return fmt.Errorf("Error in gob encoding: err=%v", err)
+		return fmt.Errorf("Error in generating snapshot: err=%v", err)
 	}
 
-	err = lop.hubbleDB.Put([]byte(memoryDBSnapshotKey), buf.Bytes())
+	err = lop.hubbleDB.Put([]byte(memoryDBSnapshotKey), snapshotBytes)
 	if err != nil {
 		return fmt.Errorf("Error in saving to DB: err=%v", err)
 	}
 
+	log.Info("Saved memory DB snapshot successfully", "accepted block", acceptedBlockNumber, "head block number", currentHeadBlock.Number(), "head block hash", currentHeadBlock.Hash())
+
 	return nil
+}
+
+func (lop *limitOrderProcesser) getLogs(fromBlock, toBlock *big.Int) []*types.Log {
+	ctx := context.Background()
+	logs, err := lop.filterAPI.GetLogs(ctx, filters.FilterCriteria{
+		FromBlock: fromBlock,
+		ToBlock:   toBlock,
+		Addresses: []common.Address{limitorders.OrderBookContractAddress, limitorders.ClearingHouseContractAddress, limitorders.MarginAccountContractAddress},
+	})
+
+	if err != nil {
+		log.Error("ListenAndProcessTransactions - GetLogs failed", "err", err)
+		panic(err)
+	}
+	return logs
 }

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -1,7 +1,10 @@
 package evm
 
 import (
+	"bytes"
 	"context"
+	"encoding/gob"
+	"fmt"
 	"math/big"
 	"sync"
 
@@ -12,9 +15,15 @@ import (
 	"github.com/ava-labs/subnet-evm/plugin/evm/limitorders"
 	"github.com/ava-labs/subnet-evm/utils"
 
+	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
+)
+
+const (
+	memoryDBSnapshotKey string = "memoryDBSnapshot"
+	snapshotInterval    uint64 = 1000 // save snapshot every 1000 blocks
 )
 
 type LimitOrderProcesser interface {
@@ -35,9 +44,10 @@ type limitOrderProcesser struct {
 	contractEventProcessor *limitorders.ContractEventsProcessor
 	buildBlockPipeline     *limitorders.BuildBlockPipeline
 	filterAPI              *filters.FilterAPI
+	hubbleDB               database.Database
 }
 
-func NewLimitOrderProcesser(ctx *snow.Context, txPool *core.TxPool, shutdownChan <-chan struct{}, shutdownWg *sync.WaitGroup, backend *eth.EthAPIBackend, blockChain *core.BlockChain, memoryDb limitorders.LimitOrderDatabase, lotp limitorders.LimitOrderTxProcessor) LimitOrderProcesser {
+func NewLimitOrderProcesser(ctx *snow.Context, txPool *core.TxPool, shutdownChan <-chan struct{}, shutdownWg *sync.WaitGroup, backend *eth.EthAPIBackend, blockChain *core.BlockChain, memoryDb limitorders.LimitOrderDatabase, hubbleDB database.Database, lotp limitorders.LimitOrderTxProcessor) LimitOrderProcesser {
 	log.Info("**** NewLimitOrderProcesser")
 	contractEventProcessor := limitorders.NewContractEventsProcessor(memoryDb)
 	buildBlockPipeline := limitorders.NewBuildBlockPipeline(memoryDb, lotp)
@@ -50,6 +60,7 @@ func NewLimitOrderProcesser(ctx *snow.Context, txPool *core.TxPool, shutdownChan
 		shutdownWg:             shutdownWg,
 		backend:                backend,
 		memoryDb:               memoryDb,
+		hubbleDB:               hubbleDB,
 		blockChain:             blockChain,
 		limitOrderTxProcessor:  lotp,
 		contractEventProcessor: contractEventProcessor,
@@ -61,13 +72,24 @@ func NewLimitOrderProcesser(ctx *snow.Context, txPool *core.TxPool, shutdownChan
 func (lop *limitOrderProcesser) ListenAndProcessTransactions() {
 	lastAccepted := lop.blockChain.LastAcceptedBlock().Number()
 	if lastAccepted.Sign() > 0 {
+		fromBlock := big.NewInt(0)
+
+		// first load the last snapshot containing data till block x, then parse all the logs since block x + 1
+		blockNumber, err := lop.loadMemoryDBSnapshot()
+		if err != nil {
+			log.Error("ListenAndProcessTransactions - Error in loading snapshot", "err", err)
+		}
+		if blockNumber > 0 {
+			log.Info("ListenAndProcessTransactions - Memory DB snapshot loaded", "blockNumber", blockNumber)
+			fromBlock = big.NewInt(int64(blockNumber + 1))
+		}
+
 		log.Info("ListenAndProcessTransactions - beginning sync", " till block number", lastAccepted)
 		ctx := context.Background()
 
-		var fromBlock, toBlock *big.Int
-		fromBlock = big.NewInt(0)
+		var toBlock *big.Int
 		toBlock = utils.BigIntMin(lastAccepted, big.NewInt(0).Add(fromBlock, big.NewInt(10000)))
-		for toBlock.Cmp(fromBlock) >= 0 {
+		for toBlock.Cmp(fromBlock) > 0 {
 			logs, err := lop.filterAPI.GetLogs(ctx, filters.FilterCriteria{
 				FromBlock: fromBlock,
 				ToBlock:   toBlock, // check that this is inclusive...
@@ -155,4 +177,72 @@ func (lop *limitOrderProcesser) handleChainAcceptedEvent(event core.ChainEvent) 
 	block := event.Block
 	log.Info("#### received ChainAcceptedEvent", "number", block.NumberU64(), "hash", block.Hash().String())
 	lop.memoryDb.Accept(block.NumberU64())
+
+	if block.NumberU64()%snapshotInterval == 0 {
+		err := lop.saveMemoryDBSnapshot(block.Number())
+		if err != nil {
+			log.Error("Error in saving memory DB snapshot", "err", err)
+		} else {
+			log.Info("Saved memory DB snapshot successfully")
+		}
+
+	}
+}
+
+func (lop *limitOrderProcesser) loadMemoryDBSnapshot() (blockNumber uint64, err error) {
+	snapshotFound, err := lop.hubbleDB.Has([]byte(memoryDBSnapshotKey))
+	if err != nil {
+		return blockNumber, fmt.Errorf("Error in checking snapshot: err=%v", err)
+	}
+
+	if !snapshotFound {
+		return blockNumber, nil
+	}
+
+	memorySnapshotBytes, err := lop.hubbleDB.Get([]byte(memoryDBSnapshotKey))
+	if err != nil {
+		return blockNumber, fmt.Errorf("Error in fetching snapshot: err=%v", err)
+	}
+
+	buf := bytes.NewBuffer(memorySnapshotBytes)
+	var snapshot limitorders.Snapshot
+	err = gob.NewDecoder(buf).Decode(&snapshot)
+	if err != nil {
+		log.Error("Error in gob parsing", "snapshotbytes", string(memorySnapshotBytes))
+		return blockNumber, fmt.Errorf("Error in json parsing: err=%v", err)
+	}
+
+	err = lop.memoryDb.LoadFromSnapshot(snapshot)
+	if err != nil {
+		return blockNumber, fmt.Errorf("Error in loading from snapshot: err=%v", err)
+	}
+
+	return snapshot.BlockNumber.Uint64(), nil
+}
+
+func (lop *limitOrderProcesser) saveMemoryDBSnapshot(blockNumber *big.Int) error {
+	memoryDb := lop.memoryDb.GetOrderBookData()
+
+	snapshot := limitorders.Snapshot{
+		Data: limitorders.InMemoryDatabase{
+			OrderMap:        memoryDb.OrderMap,
+			TraderMap:       memoryDb.TraderMap,
+			LastPrice:       memoryDb.LastPrice,
+			NextFundingTime: memoryDb.NextFundingTime,
+		},
+		BlockNumber: blockNumber,
+	}
+
+	var buf bytes.Buffer
+	err := gob.NewEncoder(&buf).Encode(&snapshot)
+	if err != nil {
+		return fmt.Errorf("Error in gob encoding: err=%v", err)
+	}
+
+	err = lop.hubbleDB.Put([]byte(memoryDBSnapshotKey), buf.Bytes())
+	if err != nil {
+		return fmt.Errorf("Error in saving to DB: err=%v", err)
+	}
+
+	return nil
 }

--- a/plugin/evm/limitorders/contract_events_processor.go
+++ b/plugin/evm/limitorders/contract_events_processor.go
@@ -118,7 +118,7 @@ func (cep *ContractEventsProcessor) handleOrderBookEvent(event *types.Log) {
 				BaseAssetQuantity:       order.BaseAssetQuantity,
 				FilledBaseAssetQuantity: big.NewInt(0),
 				Price:                   order.Price,
-				RawOrder:                args["order"],
+				RawOrder:                order,
 				Signature:               args["signature"].([]byte),
 				Salt:                    order.Salt,
 				ReduceOnly:              order.ReduceOnly,

--- a/plugin/evm/limitorders/limit_order_tx_processor.go
+++ b/plugin/evm/limitorders/limit_order_tx_processor.go
@@ -59,8 +59,8 @@ type limitOrderTxProcessor struct {
 
 // Order type is copy of Order struct defined in Orderbook contract
 type Order struct {
-	Trader            common.Address `json:"trader"`
 	AmmIndex          *big.Int       `json:"ammIndex"`
+	Trader            common.Address `json:"trader"`
 	BaseAssetQuantity *big.Int       `json:"baseAssetQuantity"`
 	Price             *big.Int       `json:"price"`
 	Salt              *big.Int       `json:"salt"`

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -578,10 +578,8 @@ func (vm *VM) SetState(_ context.Context, state snow.State) error {
 	switch state {
 	case snow.StateSyncing:
 		vm.bootstrapped = false
-		log.Info("@@@@ state-sync start")
 		return nil
 	case snow.Bootstrapping:
-		log.Info("@@@@ bootstrap start")
 		vm.bootstrapped = false
 		if err := vm.StateSyncClient.Error(); err != nil {
 			return err
@@ -589,7 +587,6 @@ func (vm *VM) SetState(_ context.Context, state snow.State) error {
 		return nil
 	case snow.NormalOp:
 		// Initialize gossip handling once we enter normal operation as there is no need to handle mempool gossip before this point.
-		log.Info("@@@@ bootstrap done")
 		vm.initBlockBuilding()
 		vm.bootstrapped = true
 		return nil
@@ -601,18 +598,14 @@ func (vm *VM) SetState(_ context.Context, state snow.State) error {
 // initBlockBuilding starts goroutines to manage block building
 func (vm *VM) initBlockBuilding() {
 	// NOTE: gossip network must be initialized first otherwise ETH tx gossip will not work.
-	log.Info("@@@@ initBlockBuilding called")
 	gossipStats := NewGossipStats()
 	vm.gossiper = vm.createGossiper(gossipStats)
 	vm.builder = vm.NewBlockBuilder(vm.toEngine)
 	vm.builder.awaitSubmittedTxs()
-	log.Info("@@@@ awaitSubmittedTxs done")
 	vm.builder.awaitBuildTimer()
-	log.Info("@@@@ awaitBuildTimer done")
 	vm.Network.SetGossipHandler(NewGossipHandler(vm, gossipStats))
 
 	vm.limitOrderProcesser.ListenAndProcessTransactions()
-	log.Info("@@@@ everything done")
 }
 
 // setAppRequestHandlers sets the request handlers for the VM to serve state sync

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -111,6 +111,7 @@ var (
 	acceptedPrefix  = []byte("snowman_accepted")
 	metadataPrefix  = []byte("metadata")
 	warpPrefix      = []byte("warp")
+	hubbleDBPrefix  = []byte("hubble")
 	ethDBPrefix     = []byte("ethdb")
 )
 
@@ -180,6 +181,10 @@ type VM struct {
 	// [warpDB] is used to store warp message signatures
 	// set to a prefixDB with the prefix [warpPrefix]
 	warpDB database.Database
+
+	// [hubbleDB] is used to store orderbook related data
+	// set to a prefixDB with the prefix [hubbleDBPrefix]
+	hubbleDB database.Database
 
 	toEngine chan<- commonEng.Message
 
@@ -274,6 +279,7 @@ func (vm *VM) Initialize(
 	vm.acceptedBlockDB = prefixdb.New(acceptedPrefix, vm.db)
 	vm.metadataDB = prefixdb.New(metadataPrefix, vm.db)
 	vm.warpDB = prefixdb.New(warpPrefix, vm.db)
+	vm.hubbleDB = prefixdb.New(hubbleDBPrefix, vm.db)
 
 	if vm.config.InspectDatabase {
 		start := time.Now()
@@ -572,8 +578,10 @@ func (vm *VM) SetState(_ context.Context, state snow.State) error {
 	switch state {
 	case snow.StateSyncing:
 		vm.bootstrapped = false
+		log.Info("@@@@ state-sync start")
 		return nil
 	case snow.Bootstrapping:
+		log.Info("@@@@ bootstrap start")
 		vm.bootstrapped = false
 		if err := vm.StateSyncClient.Error(); err != nil {
 			return err
@@ -581,6 +589,7 @@ func (vm *VM) SetState(_ context.Context, state snow.State) error {
 		return nil
 	case snow.NormalOp:
 		// Initialize gossip handling once we enter normal operation as there is no need to handle mempool gossip before this point.
+		log.Info("@@@@ bootstrap done")
 		vm.initBlockBuilding()
 		vm.bootstrapped = true
 		return nil
@@ -592,14 +601,18 @@ func (vm *VM) SetState(_ context.Context, state snow.State) error {
 // initBlockBuilding starts goroutines to manage block building
 func (vm *VM) initBlockBuilding() {
 	// NOTE: gossip network must be initialized first otherwise ETH tx gossip will not work.
+	log.Info("@@@@ initBlockBuilding called")
 	gossipStats := NewGossipStats()
 	vm.gossiper = vm.createGossiper(gossipStats)
 	vm.builder = vm.NewBlockBuilder(vm.toEngine)
 	vm.builder.awaitSubmittedTxs()
+	log.Info("@@@@ awaitSubmittedTxs done")
 	vm.builder.awaitBuildTimer()
+	log.Info("@@@@ awaitBuildTimer done")
 	vm.Network.SetGossipHandler(NewGossipHandler(vm, gossipStats))
 
 	vm.limitOrderProcesser.ListenAndProcessTransactions()
+	log.Info("@@@@ everything done")
 }
 
 // setAppRequestHandlers sets the request handlers for the VM to serve state sync
@@ -993,6 +1006,7 @@ func (vm *VM) NewLimitOrderProcesser() LimitOrderProcesser {
 		vm.eth.APIBackend,
 		vm.blockChain,
 		memoryDb,
+		vm.hubbleDB,
 		lotp,
 	)
 }


### PR DESCRIPTION
## Why this should be merged
- Right now a node restart takes a few minutes every time - approx 12 sec every 10000 blocks. It can be improved by storing snapshots in a local persistent database.

## How this works
- Saves snapshots of memory database every 1000 blocks. When a node restarts and it finds a valid snapshot, it will have to fetch only at most 1000 blocks' logs.
- There's a caveat - the stored snapshot may contain some data which was obtained after the snapshot block because the accepted block was behind the latest head block. In such a case, if a reorg happens within that chain fragment, the headBlockHash stored in the snapshot will not match the finalised state's hash at that block number and the snapshot will be discarded.

## How this was tested
- Locally
