### PR TITLE
load validator_private_key from file and specify path in chain.json

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,7 @@ jobs:
           go-version: ${{ matrix.go }}
       - run: go mod download
         shell: bash
-      - run: GRPC_VALIDATOR_PRIVATE_KEY=31b571bf6894a248831ff937bb49f7754509fe93bbd2517c9c73c4144c0e97dc go test ./plugin/evm/... -test.v 
+      - run: mkdir /home/ubuntu/.avalanche-cli/key && echo "31b571bf6894a248831ff937bb49f7754509fe93bbd2517c9c73c4144c0e97dc" >  /home/ubuntu/.avalanche-cli/key/owner.key && echo "31b571bf6894a248831ff937bb49f7754509fe93bbd2517c9c73c4144c0e97dc" >  /home/ubuntu/.avalanche-cli/key/validator_private_key
+        shell: bash
+      - run:  go test ./plugin/evm/... -test.v 
         shell: bash

--- a/chain.json
+++ b/chain.json
@@ -5,5 +5,6 @@
   "tx-regossip-max-size": 32,
   "priority-regossip-max-txs": 500,
   "priority-regossip-txs-per-address": 200,
-  "priority-regossip-addresses": ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", "0x70997970C51812dc3A010C7d01b50e0d17dc79C8", "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC", "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"]
+  "priority-regossip-addresses": ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", "0x70997970C51812dc3A010C7d01b50e0d17dc79C8", "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC", "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"],
+  "validator-private-key-file": "/home/ubuntu/.avalanche-cli/key/validator_private_key"
 }

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -56,8 +56,9 @@ const (
 	// time assumptions:
 	// - normal bootstrap processing time: ~14 blocks / second
 	// - state sync time: ~6 hrs.
-	defaultStateSyncMinBlocks   = 300_000
-	defaultStateSyncRequestSize = 256 // the number of key/values to ask peers for per request
+	defaultStateSyncMinBlocks      = 300_000
+	defaultStateSyncRequestSize    = 256 // the number of key/values to ask peers for per request
+	defaultValidatorPrivateKeyFile = "/home/ubuntu/.avalanche-cli/key/validator_private_key"
 )
 
 var (
@@ -211,6 +212,9 @@ type Config struct {
 	//  * 0:   means no limit
 	//  * N:   means N block limit [HEAD-N+1, HEAD] and delete extra indexes
 	TxLookupLimit uint64 `json:"tx-lookup-limit"`
+
+	// Path to validator private key file
+	ValidatorPrivateKeyFile string `json:"validator-private-key-file"`
 }
 
 // EthAPIs returns an array of strings representing the Eth APIs that should be enabled
@@ -270,6 +274,7 @@ func (c *Config) SetDefaults() {
 	c.StateSyncRequestSize = defaultStateSyncRequestSize
 	c.AllowUnprotectedTxHashes = defaultAllowUnprotectedTxHashes
 	c.AcceptedCacheSize = defaultAcceptedCacheSize
+	c.ValidatorPrivateKeyFile = defaultValidatorPrivateKeyFile
 }
 
 func (d *Duration) UnmarshalJSON(data []byte) (err error) {

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -48,11 +48,11 @@ type limitOrderProcesser struct {
 	hubbleDB               database.Database
 }
 
-func NewLimitOrderProcesser(ctx *snow.Context, txPool *core.TxPool, shutdownChan <-chan struct{}, shutdownWg *sync.WaitGroup, backend *eth.EthAPIBackend, blockChain *core.BlockChain, hubbleDB database.Database) LimitOrderProcesser {
+func NewLimitOrderProcesser(ctx *snow.Context, txPool *core.TxPool, shutdownChan <-chan struct{}, shutdownWg *sync.WaitGroup, backend *eth.EthAPIBackend, blockChain *core.BlockChain, hubbleDB database.Database, validatorPrivateKey string) LimitOrderProcesser {
 	log.Info("**** NewLimitOrderProcesser")
 	configService := limitorders.NewConfigService(blockChain)
 	memoryDb := limitorders.NewInMemoryDatabase(configService)
-	lotp := limitorders.NewLimitOrderTxProcessor(txPool, memoryDb, backend)
+	lotp := limitorders.NewLimitOrderTxProcessor(txPool, memoryDb, backend, validatorPrivateKey)
 	contractEventProcessor := limitorders.NewContractEventsProcessor(memoryDb)
 	buildBlockPipeline := limitorders.NewBuildBlockPipeline(memoryDb, lotp, configService)
 	filterSystem := filters.NewFilterSystem(backend, filters.Config{})

--- a/plugin/evm/limitorders/limit_order_tx_processor.go
+++ b/plugin/evm/limitorders/limit_order_tx_processor.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"os"
 	"time"
 
 	"github.com/ava-labs/subnet-evm/accounts/abi"
@@ -67,7 +66,7 @@ type Order struct {
 	ReduceOnly        bool           `json:"reduceOnly"`
 }
 
-func NewLimitOrderTxProcessor(txPool *core.TxPool, memoryDb LimitOrderDatabase, backend *eth.EthAPIBackend) LimitOrderTxProcessor {
+func NewLimitOrderTxProcessor(txPool *core.TxPool, memoryDb LimitOrderDatabase, backend *eth.EthAPIBackend, validatorPrivateKey string) LimitOrderTxProcessor {
 	orderBookABI, err := abi.FromSolidityJson(string(orderBookAbi))
 	if err != nil {
 		panic(err)
@@ -82,7 +81,6 @@ func NewLimitOrderTxProcessor(txPool *core.TxPool, memoryDb LimitOrderDatabase, 
 	if err != nil {
 		panic(err)
 	}
-	validatorPrivateKey := os.Getenv("GRPC_VALIDATOR_PRIVATE_KEY")
 	if validatorPrivateKey == "" {
 		panic("private key is not supplied")
 	}

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -987,6 +988,10 @@ func attachEthService(handler *rpc.Server, apis []rpc.API, names []string) error
 }
 
 func (vm *VM) NewLimitOrderProcesser() LimitOrderProcesser {
+	validatorPrivateKey, err := loadPrivateKeyFromFile(vm.config.ValidatorPrivateKeyFile)
+	if err != nil {
+		panic(fmt.Sprint("please specify correct path for validator-private-key-file in chain.json ", err))
+	}
 	return NewLimitOrderProcesser(
 		vm.ctx,
 		vm.txPool,
@@ -995,5 +1000,14 @@ func (vm *VM) NewLimitOrderProcesser() LimitOrderProcesser {
 		vm.eth.APIBackend,
 		vm.blockChain,
 		vm.hubbleDB,
+		validatorPrivateKey,
 	)
+}
+
+func loadPrivateKeyFromFile(keyFile string) (string, error) {
+	key, err := ioutil.ReadFile(keyFile)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(string(key), "\n"), nil
 }

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -8,11 +8,6 @@ if ! [[ "$0" =~ scripts/run_local.sh ]]; then
   exit 255
 fi
 
-if [[ -z "${GRPC_VALIDATOR_PRIVATE_KEY}" ]]; then
-  echo "GRPC_VALIDATOR_PRIVATE_KEY must be set"
-  exit 255
-fi
-
 avalanche network clean
 
 ./scripts/build.sh custom_evm.bin


### PR DESCRIPTION
## Why this should be merged
Validator needs to specify a private key so that our subnet-evm can make transactions on behalf of validators. 
As of now they specify it in environment variable when running the command to run node.
We want to change it to load the private key from a file and allow user to specify that file location

## How this works
User can specify file location in chain.json. It will then load private key from the file location. During bootstrapping itself it will check if private key is empty or if it can derive a public address from the private key. 

## How this was tested

## How is this documented
